### PR TITLE
HDDS-4415. Add mail lists page on ozone website

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -30,8 +30,8 @@ If you’d like to see changes made in the Ozone issue tracking system, please s
 
 The Ozone issues mailing list is: issues@ozone.apache.org.
 
-* [Subscribe to List](issues-subscribe@ozone.apache.org)
-* [Unsubscribe from List](issues-unsubscribe@ozone.apache.org)
+* [Subscribe to List](mailto:issues-subscribe@ozone.apache.org)
+* [Unsubscribe from List](mailto:issues-unsubscribe@ozone.apache.org)
 * [Archives](http://mail-archives.apache.org/mod_mbox/ozone-issues/)
 
 ## Ozone Slack

--- a/content/community.md
+++ b/content/community.md
@@ -28,7 +28,7 @@ The Ozone commits mailing list is: commits@ozone.apache.org.
 
 If you’d like to see changes made in the Ozone issue tracking system, please subscribe to the Ozone issues mailing list.
 
-The Ozone issues mailing list is: ssues@ozone.apache.org.
+The Ozone issues mailing list is: issues@ozone.apache.org.
 
 * [Subscribe to List](issues-subscribe@ozone.apache.org)
 * [Unsubscribe from List](issues-unsubscribe@ozone.apache.org)

--- a/content/community.md
+++ b/content/community.md
@@ -1,0 +1,63 @@
+---
+title: Ozone Community
+---
+
+## Ozone Mailing Lists
+
+### Developers
+
+If you’d like to contribute to Ozone, please subscribe to the Hadoop developer mailing list.
+
+The Ozone developer mailing list is: ozone-dev@hadoop.apache.org.
+
+* [Subscribe to List](ozone-dev-subscribe@hadoop.apache.org)
+* [Unsubscribe from List](ozone-dev-unsubscribe@hadoop.apache.org)
+* [Archives](http://mail-archives.apache.org/mod_mbox/hadoop-ozone-dev/)
+
+### Commits
+
+If you’d like to see changes made in the Ozone version control system, please subscribe to the Ozone commits mailing list.
+
+The Ozone commits mailing list is: ozone-commits@hadoop.apache.org.
+
+* [Subscribe to List](ozone-commits-subscribe@hadoop.apache.org)
+* [Unsubscribe from List](ozone-commits-unsubscribe@hadoop.apache.org)
+* [Archives](http://mail-archives.apache.org/mod_mbox/hadoop-ozone-commits/)
+
+### Issues
+
+If you’d like to see changes made in the Ozone issue tracking system, please subscribe to the Ozone issues mailing list.
+
+The Ozone issues mailing list is: ozone-issues@hadoop.apache.org.
+
+* [Subscribe to List](ozone-issues-subscribe@hadoop.apache.org)
+* [Unsubscribe from List](ozone-issues-unsubscribe@hadoop.apache.org)
+* [Archives](http://mail-archives.apache.org/mod_mbox/hadoop-ozone-issues/)
+
+## Ozone Slack
+
+If you would like to join the Ozone slack Channel, Please use this link to get self-invited  https://s.apache.org/slack-invite and join the **#ozone** channel.
+
+## Ozone Community Calls
+
+### Monday sync:
+
+* Time: 04:00 PM UTC or [Convert to your local time](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC)
+    1. **West Coast**: 9:00 AM
+    2. **East Coast**: 12:00 PM
+    3. **Ireland / Great Britain**: 05:00 PM
+    4. **Central Europe**: 06:00 PM
+    5. **India**: 9:30 PM
+    6. **China**: 12:00 
+* **Zoom link**: https://zoom.us/j/922195972
+
+### Friday (Thursday Pacific) sync:
+
+* Time: 04:15 AM UTC or [Convert to your local time](http://www.thetimezoneconverter.com/?t=04:15&tz=UTC)
+    1. **West Coast**: 9:15 PM (Thursday)
+    2. **East Coast**: 12:15 AM
+    3. **Ireland / Great Britain**: 05:00 AM
+    4. **Central Europe**: 06:15 AM
+    5. **India**: 9:45 AM
+    6. **China**: 12:15 PM
+* **Zoom link**: https://cloudera.zoom.us/j/5780476042

--- a/content/community.md
+++ b/content/community.md
@@ -40,24 +40,4 @@ If you would like to join the Ozone slack Channel, Please use this link to get s
 
 ## Ozone Community Calls
 
-### Monday sync:
-
-* Time: 04:00 PM UTC or [Convert to your local time](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC)
-    1. **West Coast**: 9:00 AM
-    2. **East Coast**: 12:00 PM
-    3. **Ireland / Great Britain**: 05:00 PM
-    4. **Central Europe**: 06:00 PM
-    5. **India**: 9:30 PM
-    6. **China**: 12:00 
-* **Zoom link**: https://zoom.us/j/922195972
-
-### Friday (Thursday Pacific) sync:
-
-* Time: 04:15 AM UTC or [Convert to your local time](http://www.thetimezoneconverter.com/?t=04:15&tz=UTC)
-    1. **West Coast**: 9:15 PM (Thursday)
-    2. **East Coast**: 12:15 AM
-    3. **Ireland / Great Britain**: 05:00 AM
-    4. **Central Europe**: 06:15 AM
-    5. **India**: 9:45 AM
-    6. **China**: 12:15 PM
-* **Zoom link**: https://cloudera.zoom.us/j/5780476042
+Please refer to [this page](https://cwiki.apache.org/confluence/display/HADOOP/Ozone+Community+Calls) to get more information.

--- a/content/community.md
+++ b/content/community.md
@@ -20,8 +20,8 @@ If you’d like to see changes made in the Ozone version control system, please 
 
 The Ozone commits mailing list is: commits@ozone.apache.org.
 
-* [Subscribe to List](commits-subscribe@ozone.apache.org)
-* [Unsubscribe from List](commits-unsubscribe@ozone.apache.org)
+* [Subscribe to List](mailto:commits-subscribe@ozone.apache.org)
+* [Unsubscribe from List](mailto:commits-unsubscribe@ozone.apache.org)
 * [Archives](http://mail-archives.apache.org/mod_mbox/ozone-commits/)
 
 ### Issues

--- a/content/community.md
+++ b/content/community.md
@@ -6,7 +6,7 @@ title: Ozone Community
 
 ### Developers
 
-If you’d like to contribute to Ozone, please subscribe to the Hadoop developer mailing list.
+If you’d like to contribute to Ozone, please subscribe to the Ozone developer mailing list.
 
 The Ozone developer mailing list is: dev@ozone.apache.org.
 

--- a/content/community.md
+++ b/content/community.md
@@ -12,7 +12,7 @@ The Ozone developer mailing list is: dev@ozone.apache.org.
 
 * [Subscribe to List](mailto:dev-subscribe@ozone.apache.org)
 * [Unsubscribe from List](mailto:dev-unsubscribe@ozone.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/ozone-dev/)
+* [Archives](https://mail-archives.apache.org/mod_mbox/ozone-dev/)
 
 ### Commits
 
@@ -22,7 +22,7 @@ The Ozone commits mailing list is: commits@ozone.apache.org.
 
 * [Subscribe to List](mailto:commits-subscribe@ozone.apache.org)
 * [Unsubscribe from List](mailto:commits-unsubscribe@ozone.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/ozone-commits/)
+* [Archives](https://mail-archives.apache.org/mod_mbox/ozone-commits/)
 
 ### Issues
 
@@ -32,11 +32,11 @@ The Ozone issues mailing list is: issues@ozone.apache.org.
 
 * [Subscribe to List](mailto:issues-subscribe@ozone.apache.org)
 * [Unsubscribe from List](mailto:issues-unsubscribe@ozone.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/ozone-issues/)
+* [Archives](https://mail-archives.apache.org/mod_mbox/ozone-issues/)
 
 ## Ozone Slack
 
-If you would like to join the Ozone slack Channel, Please use this link to get self-invited  https://s.apache.org/slack-invite and join the **#ozone** channel.
+If you would like to join the Ozone Slack Channel, please use this link to get self-invited  https://s.apache.org/slack-invite and join the **#ozone** channel.
 
 ## Ozone Community Calls
 

--- a/content/community.md
+++ b/content/community.md
@@ -9,6 +9,7 @@ title: Ozone Community
 If you’d like to contribute to Ozone, please subscribe to the Hadoop developer mailing list.
 
 The Ozone developer mailing list is: dev@ozone.apache.org.
+
 * [Subscribe to List](dev-subscribe@ozone.apache.org)
 * [Unsubscribe from List](dev-unsubscribe@ozone.apache.org)
 * [Archives](http://mail-archives.apache.org/mod_mbox/ozone-dev/)

--- a/content/community.md
+++ b/content/community.md
@@ -34,6 +34,14 @@ The Ozone issues mailing list is: issues@ozone.apache.org.
 * [Unsubscribe from List](mailto:issues-unsubscribe@ozone.apache.org)
 * [Archives](https://mail-archives.apache.org/mod_mbox/ozone-issues/)
 
+### Older Archives
+
+Ozone was approved as a separate Apache project in Oct. 2020, and the previous mailing list archives can be found here.
+
+* [Developers](https://mail-archives.apache.org/mod_mbox/hadoop-ozone-dev/)
+* [Commits](https://mail-archives.apache.org/mod_mbox/hadoop-ozone-commits/)
+* [Issues](https://mail-archives.apache.org/mod_mbox/hadoop-ozone-issues/)
+
 ## Ozone Slack
 
 If you would like to join the Ozone Slack Channel, please use this link to get self-invited  https://s.apache.org/slack-invite and join the **#ozone** channel.

--- a/content/community.md
+++ b/content/community.md
@@ -8,31 +8,30 @@ title: Ozone Community
 
 If you’d like to contribute to Ozone, please subscribe to the Hadoop developer mailing list.
 
-The Ozone developer mailing list is: ozone-dev@hadoop.apache.org.
-
-* [Subscribe to List](ozone-dev-subscribe@hadoop.apache.org)
-* [Unsubscribe from List](ozone-dev-unsubscribe@hadoop.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/hadoop-ozone-dev/)
+The Ozone developer mailing list is: dev@ozone.apache.org.
+* [Subscribe to List](dev-subscribe@ozone.apache.org)
+* [Unsubscribe from List](dev-unsubscribe@ozone.apache.org)
+* [Archives](http://mail-archives.apache.org/mod_mbox/ozone-dev/)
 
 ### Commits
 
 If you’d like to see changes made in the Ozone version control system, please subscribe to the Ozone commits mailing list.
 
-The Ozone commits mailing list is: ozone-commits@hadoop.apache.org.
+The Ozone commits mailing list is: commits@ozone.apache.org.
 
-* [Subscribe to List](ozone-commits-subscribe@hadoop.apache.org)
-* [Unsubscribe from List](ozone-commits-unsubscribe@hadoop.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/hadoop-ozone-commits/)
+* [Subscribe to List](commits-subscribe@ozone.apache.org)
+* [Unsubscribe from List](commits-unsubscribe@ozone.apache.org)
+* [Archives](http://mail-archives.apache.org/mod_mbox/ozone-commits/)
 
 ### Issues
 
 If you’d like to see changes made in the Ozone issue tracking system, please subscribe to the Ozone issues mailing list.
 
-The Ozone issues mailing list is: ozone-issues@hadoop.apache.org.
+The Ozone issues mailing list is: ssues@ozone.apache.org.
 
-* [Subscribe to List](ozone-issues-subscribe@hadoop.apache.org)
-* [Unsubscribe from List](ozone-issues-unsubscribe@hadoop.apache.org)
-* [Archives](http://mail-archives.apache.org/mod_mbox/hadoop-ozone-issues/)
+* [Subscribe to List](issues-subscribe@ozone.apache.org)
+* [Unsubscribe from List](issues-unsubscribe@ozone.apache.org)
+* [Archives](http://mail-archives.apache.org/mod_mbox/ozone-issues/)
 
 ## Ozone Slack
 

--- a/content/community.md
+++ b/content/community.md
@@ -10,8 +10,8 @@ If you’d like to contribute to Ozone, please subscribe to the Ozone developer 
 
 The Ozone developer mailing list is: dev@ozone.apache.org.
 
-* [Subscribe to List](dev-subscribe@ozone.apache.org)
-* [Unsubscribe from List](dev-unsubscribe@ozone.apache.org)
+* [Subscribe to List](mailto:dev-subscribe@ozone.apache.org)
+* [Unsubscribe from List](mailto:dev-unsubscribe@ozone.apache.org)
 * [Archives](http://mail-archives.apache.org/mod_mbox/ozone-dev/)
 
 ### Commits

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -75,6 +75,7 @@
                     <li><a href="faq">FAQ</a></li>
                     <li><a href="downloads">Download</a></li>
                     <li><a href="docs">Documentation</a></li>
+                    <li><a href="community">Community</a></li>
                     <li><a href="https://github.com/apache/hadoop-ozone">Source</a></li>
                     <li><a href="https://cwiki.apache.org/confluence/display/HADOOP/Ozone+Contributor+Guide">Wiki</a></li>
                 </ul>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add **Community** menu.
This page contains Ozone mailing list, Ozone slack, Ozone community call.

But there is a question: Should I add past mailing archives to this page?
Like this http://mail-archives.apache.org/mod_mbox/hadoop-ozone-dev/

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4415

## How was this patch tested?

Locally with hugo.

![Apache Ozone - localhost](https://user-images.githubusercontent.com/2565172/98227395-3c29f100-1f92-11eb-99b6-986fbbf90696.png)
