### PR TITLE
HDDS-5036. Apply merge/notification settings to ozone-site repo

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 github:
   description: "Website for Apache Ozone"
   homepage: https://ozone.apache.org/
+  labels:
+    - ozone
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+notifications:
+  commits:      commits@ozone.apache.org
+  issues:       issues@ozone.apache.org
+  pullrequests: issues@ozone.apache.org
+  jira_options: link label


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Only allow squash merge.
 * Send issue/PR updates to `issues@`, not `dev@`.
 * Add PR link and label in Jira.

https://issues.apache.org/jira/browse/HDDS-5036

## How was this patch tested?

Not tested, but same settings worked for other Ozone repos.