### PR TITLE
HDDS-5096. Adjust download pages to use Apache Ozone (tlp) artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ which starts an internal server where you can always check the final rendered ve
 
 ## Update ozone.apache.org
 
-For modify the content the [Ozone site](https://ozone.apache.org) the rendered version should be committed to the [asf-site](https://github.com/apache/hadoop-site/tree/asf-site) branch.
+For modify the content the [Ozone site](https://ozone.apache.org) the rendered version should be committed to the [asf-site](https://github.com/apache/ozone-site/tree/asf-site) branch.
 
 This is handled by a [Github Action](https://github.com/apache/ozone-site/blob/master/.github/workflows/regenerate.yml) which refresh the rendered branch and commit the changes: *It's enough to modify the source files on this branch, no other action is required.* Updating the Hugo source files on this branch will automatically update the site itself.
 

--- a/content/downloads.md
+++ b/content/downloads.md
@@ -17,28 +17,27 @@ type: custompage
   limitations under the License. See accompanying LICENSE file.
 -->
 
-## To verify Hadoop Ozone releases using GPG:
+## To verify Apache Ozone releases using GPG:
 
-1.  Download the release hadoop-ozone-X.Y.Z-src.tar.gz from a [mirror
-    site](https://www.apache.org/dyn/closer.cgi/hadoop/ozone).
-2.  Download the signature file hadoop-ozone-X.Y.Z-src.tar.gz.asc from
-    [Apache](https://dist.apache.org/repos/dist/release/hadoop/ozone/).
+1.  Download the release ozone-X.Y.Z-src.tar.gz from a [mirror
+    site](https://www.apache.org/dyn/closer.cgi/ozone).
+2.  Download the signature file ozone-X.Y.Z-src.tar.gz.asc from
+    [Apache](https://dist.apache.org/repos/dist/release/ozone/).
 3.  Download the [Hadoop
-    KEYS](https://dist.apache.org/repos/dist/release/hadoop/common/KEYS)
+    KEYS](https://dist.apache.org/repos/dist/release/ozone/KEYS)
     file.
 4.  gpg --import KEYS
-5.  gpg --verify hadoop-X.Y.Z-src.tar.gz.asc
+5.  gpg --verify ozone-X.Y.Z-src.tar.gz.asc
 
 ## To perform a quick check using SHA-256:
 
-1.  Download the release hadoop-ozone-X.Y.Z-src.tar.gz from a [mirror
+1.  Download the release ozone-X.Y.Z-src.tar.gz from a [mirror
     site](https://www.apache.org/dyn/closer.cgi/hadoop/ozone).
-2.  Download the checksum hadoop-ozone-X.Y.Z-src.tar.gz.mds from
+2.  Download the checksum ozone-X.Y.Z-src.tar.gz.sha512 from
     [Apache](https://dist.apache.org/repos/dist/release/hadoop/ozone/).
-3.  shasum -a 256 hadoop-ozone-X.Y.Z-src.tar.gz
+3.  sha512sum -c ozone-X.Y.Z-src.tar.gz
 
-All previous releases of Hadoop Ozone are available from the [Apache release
-archive](https://archive.apache.org/dist/hadoop/ozone/) site.
+Note: Before 1.1.0 release Ozone was part of the Apache Hadoop project. Older release artifacts can be found [there](https://archive.apache.org/dist/hadoop/ozone/).
 
 ## License
 

--- a/content/release/0.2.1-alpha.md
+++ b/content/release/0.2.1-alpha.md
@@ -1,7 +1,7 @@
 ---
 title: Release 0.2.1-alpha available
 date: 2018-10-01
-linked: true
+hadoop: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/0.3.0-alpha.md
+++ b/content/release/0.3.0-alpha.md
@@ -1,7 +1,7 @@
 ---
 title: Release 0.3.0-alpha available
 date: 2018-11-22
-linked: true
+hadoop: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/0.4.0-alpha.md
+++ b/content/release/0.4.0-alpha.md
@@ -1,7 +1,7 @@
 ---
 title: Release 0.4.0-alpha available
 date: 2019-05-07
-linked: true
+hadoop: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/0.4.1-alpha.md
+++ b/content/release/0.4.1-alpha.md
@@ -1,7 +1,7 @@
 ---
 title: Release 0.4.1-alpha available
 date: 2019-10-13
-linked: true
+hadoop: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/0.5.0-beta.md
+++ b/content/release/0.5.0-beta.md
@@ -2,6 +2,7 @@
 title: Release 0.5.0-beta available
 date: 2020-03-24
 linked: true
+hadoop: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/1.0.0.md
+++ b/content/release/1.0.0.md
@@ -2,6 +2,7 @@
 title: Release 1.0.0 available
 date: 2020-09-02
 linked: true
+hadoop: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -16,9 +16,9 @@
 
   <h1>Download</h1>
 
-  <p>Hadoop Ozone is released as source code tarballs with corresponding binary
+  <p>Apache Ozone is released as source code tarballs with corresponding binary
   tarballs for convenience. The downloads are distributed via mirror sites
-  and should be checked for tampering using GPG or SHA-256.</p>
+  and should be checked for tampering using GPG or SHA-512.</p>
 
 <p>
   <table class="table table-striped">
@@ -35,19 +35,35 @@
      <tr>
        <td>{{.File.BaseFileName }}</td>
        <td>{{dateFormat "2006 Jan 2 " .Date}}</td>
-       <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
-         (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
-         <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
-        </td>
-        <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
-          (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
-          <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+       {{ if eq .Params.hadoop true }}
+         <td>
+           <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
+           (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
+           <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
+          </td>
+          <td>
+            <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
+            (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
+            <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+           </td>
+           <td>
+             <a href="release/{{.File.BaseFileName }}/">Announcement</a>
+           </td>
+       {{else}}
+         <td>
+           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
+           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
+           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+         </td>
+         <td>
+           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
+           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
+           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="release/{{.File.BaseFileName }}/">Announcement</a>
          </td>
+       {{end}}
      </tr>
   {{end}}
   </table>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,<br/>
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,<br/>
                 Apache, Apache Hadoop, the Apache feather logo, are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/layouts/release/single.html
+++ b/layouts/release/single.html
@@ -19,18 +19,42 @@
 {{.Content}}
 </div>
 <div class="col-md-4" style="padding: 20px;">
-   <p><a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz" class="btn btn-success">Download tar.gz</a></p>
-   <p>
-     (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
-     <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
-   </p>
-   <p><a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz" class="btn btn-warning">Download src</a></p>
-   <p>
-     (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
-     <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
-   </p>
-      <p><a href="https://hadoop.apache.org/ozone/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a></p>
-   <p><small>{{dateFormat "2006 Jan 2 " .Date}}</small></p>
+    {{ if eq .Params.hadoop true }}
+       <p>
+           <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz"
+              class="btn btn-success">Download tar.gz</a></p>
+       <p>
+           (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
+           <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+       </p>
+       <p>
+           <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz"
+              class="btn btn-warning">Download src</a></p>
+       <p>
+           (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
+           <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
+       </p>
+       <p><a href="https://hadoop.apache.org/ozone/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
+       </p>
+    {{else}}
+       <p>
+           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz"
+              class="btn btn-success">Download tar.gz</a></p>
+       <p>
+           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
+           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+       </p>
+       <p>
+           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz"
+              class="btn btn-warning">Download src</a></p>
+       <p>
+           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
+           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
+       </p>
+       <p><a href="https://hadoop.apache.org/ozone/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
+       </p>
+    {{end}}
+    <p><small>{{dateFormat "2006 Jan 2 " .Date}}</small></p>
 
 </div>
 </div>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-5096

Apache Ozone is separated from Apache Hadoop, it's not a Hadoop subproject anymore but a top-level Apache project (TLP).

The release page should be updated to use the new release artifact name scheme. (Old releases can be marked with a Hadoop flag to use the old URL scheme for releases before 1.1.0)

(some trivial typos / copyright year is also updated in this patch and very old releases are removed from the download page).

## How can it be tested?

To test, create a `content/release/1.1.0.md` file:

```
---
title: Release 1.1.0 available
date: 2021-03-02
linked: true
---
TODO
```

And start the preview:

```
hugo serve
```

And check the download page: http://localhost:1313/downloads/