### PR TITLE
HDDS-5121. fix download page to use ozone space instead of hadoop

### DIFF
--- a/content/release/1.1.0.md
+++ b/content/release/1.1.0.md
@@ -2,7 +2,6 @@
 title: Release 1.1.0 available
 date: 2021-04-17
 linked: true
-hadoop: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -51,14 +51,14 @@
            </td>
        {{else}}
          <td>
-           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
-           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
-           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
-         </td>
-         <td>
            <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
            (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
            <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
+         </td>
+         <td>
+           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
+           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
+           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="release/{{.File.BaseFileName }}/">Announcement</a>


### PR DESCRIPTION
Ozone tar files uploaded to the old hadoop namespace. As Ozone is not Hadoop any more they supposed to be uploaded to  the ozone project space. 

I moved the artifacts:

```
svn mv https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-1.1.0 https://dist.apache.org/repos/dist/release/ozone/1.1.0
```

But proper linking requires this one flag turning off.
