### PR TITLE
HDDS-5121. Fixing index.html to point to 1.1.0 release.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,7 +25,7 @@
             </p>
             </p>
             <p></p>
-            <p class="lead">Ozone is now Generally Available(GA) with <a href="release/1.0.0/">1.0.0</a> release.
+            <p class="lead">Ozone is now Generally Available(GA) with <a href="release/1.1.0/">1.1.0</a> release.
             </p>
             <p></p>
         </div>


### PR DESCRIPTION
Fixing Index.html to point to 1.1.0 release instead of 1.0.0 release.