### PR TITLE
Revert "HDDS-5070. Fix broken download links for 1.1.0. (#9)"

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -105,14 +105,14 @@
        <td>2021 Apr 17 </td>
        
          <td>
-           <a href="https://www.apache.org/dyn/closer.cgi/ozone/1.1.0/ozone-1.1.0-src.tar.gz">source</a>
-           (<a href="https://dist.apache.org/repos/dist/release/ozone/1.1.0/ozone-1.1.0-src.tar.gz.mds">checksum</a>
-           <a href="https://dist.apache.org/repos/dist/release/ozone/1.1.0/ozone-1.1.0-src.tar.gz.asc">signature</a>)
+           <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-1.1.0/hadoop-ozone-1.1.0-src.tar.gz">source</a>
+           (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-1.1.0/hadoop-ozone-1.1.0-src.tar.gz.mds">checksum</a>
+           <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-1.1.0/hadoop-ozone-1.1.0-src.tar.gz.asc">signature</a>)
           </td>
           <td>
-            <a href="https://www.apache.org/dyn/closer.cgi/ozone/1.1.0/ozone-1.1.0.tar.gz">binary</a>
-            (<a href="https://dist.apache.org/repos/dist/release/ozone/1.1.0/ozone-1.1.0.tar.gz.mds">checksum</a>
-            <a href="https://dist.apache.org/repos/dist/release/ozone/1.1.0/ozone-1.1.0.tar.gz.asc">signature</a>)
+            <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-1.1.0/hadoop-ozone-1.1.0.tar.gz">binary</a>
+            (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-1.1.0/hadoop-ozone-1.1.0.tar.gz.mds">checksum</a>
+            <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-1.1.0/hadoop-ozone-1.1.0.tar.gz.asc">signature</a>)
            </td>
            <td>
              <a href="release/1.1.0/">Announcement</a>


### PR DESCRIPTION
This reverts commit 147e2c74accef371bb25c407e34849d72407016d.

The change is reverted since it needs to be updated in the master branch first.