### PR TITLE
HDDS-5121. Fixing broken download links for 1.1.0 release.

### DIFF
--- a/content/release/1.1.0.md
+++ b/content/release/1.1.0.md
@@ -2,7 +2,7 @@
 title: Release 1.1.0 available
 date: 2021-04-17
 linked: true
-hadoop: true
+hadoop: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixing broken download link in ozone site master branch.

Tested with generating the site with Hugo followed by
running the local web server in "public: directory.