### PR TITLE
HDDS-5694. Download page must not use dist.apache.org

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache Hadoop Ozone Releases"
+title: "Apache Ozone Releases"
 layout: downloads
 type: custompage
 ---
@@ -22,20 +22,19 @@ type: custompage
 1.  Download the release ozone-X.Y.Z-src.tar.gz from a [mirror
     site](https://www.apache.org/dyn/closer.cgi/ozone).
 2.  Download the signature file ozone-X.Y.Z-src.tar.gz.asc from
-    [Apache](https://dist.apache.org/repos/dist/release/ozone/).
-3.  Download the [Hadoop
-    KEYS](https://dist.apache.org/repos/dist/release/ozone/KEYS)
+    [Apache](https://downloads.apache.org/ozone/).
+3.  Download the Ozone [KEYS](https://downloads.apache.org/ozone/KEYS)
     file.
-4.  gpg --import KEYS
-5.  gpg --verify ozone-X.Y.Z-src.tar.gz.asc
+4.  `gpg --import KEYS`
+5.  `gpg --verify ozone-X.Y.Z-src.tar.gz.asc ozone-X.Y.Z-src.tar.gz`
 
-## To perform a quick check using SHA-256:
+## To perform a quick check using SHA-512:
 
 1.  Download the release ozone-X.Y.Z-src.tar.gz from a [mirror
     site](https://www.apache.org/dyn/closer.cgi/hadoop/ozone).
 2.  Download the checksum ozone-X.Y.Z-src.tar.gz.sha512 from
-    [Apache](https://dist.apache.org/repos/dist/release/hadoop/ozone/).
-3.  sha512sum -c ozone-X.Y.Z-src.tar.gz
+    [Apache](https://downloads.apache.org/ozone/).
+3.  `sha512sum -c ozone-X.Y.Z-src.tar.gz`
 
 Note: Before 1.1.0 release Ozone was part of the Apache Hadoop project. Older release artifacts can be found [there](https://archive.apache.org/dist/hadoop/ozone/).
 

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -38,13 +38,13 @@
        {{ if eq .Params.hadoop true }}
          <td>
            <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
-           (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
-           <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
+           (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
+           <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
           </td>
           <td>
             <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
-            (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
-            <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+            (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
+            <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
            </td>
            <td>
              <a href="release/{{.File.BaseFileName }}/">Announcement</a>
@@ -52,13 +52,13 @@
        {{else}}
          <td>
            <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
-           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
-           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
+           (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
+           <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
-           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
-           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+           (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
+           <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="release/{{.File.BaseFileName }}/">Announcement</a>

--- a/layouts/release/single.html
+++ b/layouts/release/single.html
@@ -24,15 +24,15 @@
            <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz"
               class="btn btn-success">Download tar.gz</a></p>
        <p>
-           (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
-           <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+           (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
+           <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
        </p>
        <p>
            <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz"
               class="btn btn-warning">Download src</a></p>
        <p>
-           (<a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
-           <a href="https://dist.apache.org/repos/dist/release/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
+           (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
+           <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
        </p>
        <p><a href="https://hadoop.apache.org/ozone/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
        </p>
@@ -41,15 +41,15 @@
            <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz"
               class="btn btn-success">Download tar.gz</a></p>
        <p>
-           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
-           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+           (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
+           <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
        </p>
        <p>
            <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz"
               class="btn btn-warning">Download src</a></p>
        <p>
-           (<a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
-           <a href="https://dist.apache.org/repos/dist/release/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
+           (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
+           <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
        </p>
        <p><a href="https://hadoop.apache.org/ozone/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
        </p>


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Fix verify commands to have `--`, not some HTML entity.
* Fix checksum/signature URLs.

https://issues.apache.org/jira/browse/HDDS-5694

## How was this patch tested?

```
hugo serve
open http://localhost:1313/downloads
open http://localhost:1313/release/1.1.0/
```

Verified dashes in commands.
Verified checksum/signature URLs work and refer to downloads.apache.org, not dist.apache.org.