### PR TITLE
HDDS-4903. Add Ozone logo to the website

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -43,7 +43,7 @@
         <ul class="breadcrumb col-md-6">
             <li>
                 <img class="asf-logo" src="asf_feather.png"/>
-                <a  href="https://www.apache.org">Apache Software Foundation</span></a>
+                <a  href="https://www.apache.org">Apache Software Foundation</a>
             </li>
         </ul>
         <div class="col-md-6">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -45,7 +45,6 @@
                 <img class="asf-logo" src="asf_feather.png"/>
                 <a  href="https://www.apache.org">Apache Software Foundation</span></a>
             </li>
-            <li><a href="{{.Site.BaseURL}}">Ozone&trade;</a></li>
         </ul>
         <div class="col-md-6">
             <ul class="pull-right breadcrumb">
@@ -55,6 +54,20 @@
                 <li><a href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
                 <li><a href="https://www.apache.org/security/">Security</a></li>
         </ul>
+        </div>
+    </div>
+    <div class="container">
+        <ul class="breadcrumb col-md-6">
+            <li><h1 style="color:#000">
+                <img src="ozone-logo.png" alt="Ozone logo" height="60"/>
+                <a href="{{.Site.BaseURL}}">Ozone&trade;</a>
+            </h1></li>
+        </ul>
+        <div class="col-md-6">
+            <ul class="pull-right breadcrumb">
+                <li><h1><a class="acevent" data-format="wide" href="https://www.apachecon.com/"><img title="Apache Events Calendar" alt="Apache Events Calendar" src="https://www.apachecon.com/event-images/default-wide-light.png" style="max-width: 240px;"></a>
+                </h1></li>
+            </ul>
         </div>
     </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -43,7 +43,7 @@
         <ul class="breadcrumb col-md-6">
             <li>
                 <img class="asf-logo" src="asf_feather.png"/>
-                <a  href="https://www.apache.org">Apache Software Foundation</a>
+                <a href="https://www.apache.org">Apache Software Foundation</a>
             </li>
         </ul>
         <div class="col-md-6">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -60,7 +60,7 @@
         <ul class="breadcrumb col-md-6">
             <li><h1 style="color:#000">
                 <img src="ozone-logo.png" alt="Ozone logo" height="60"/>
-                <a href="{{.Site.BaseURL}}">Ozone&trade;</a>
+                <a href="{{.Site.BaseURL}}">Apache Ozone&trade;</a>
             </h1></li>
         </ul>
         <div class="col-md-6">


### PR DESCRIPTION
# What changes were proposed in this pull request?

Add logo to the website just like [Ratis](https://ratis.apache.org). See also: #16

https://issues.apache.org/jira/browse/HDDS-4903

<img width="900" alt="navbar-logo-v2" src="https://user-images.githubusercontent.com/5821159/139228014-6ea36deb-9655-4408-a324-ebda1357ee5d.png">


