### PR TITLE
HDDS-6006. Leftover links pointing to hadoop.apache.org

### DIFF
--- a/layouts/release/single.html
+++ b/layouts/release/single.html
@@ -51,7 +51,7 @@
            (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
            <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
        </p>
-       <p><a href="https://hadoop.apache.org/ozone/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
+       <p><a href="https://ozone.apache.org/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
        </p>
     {{end}}
     <p><small>{{dateFormat "2006 Jan 2 " .Date}}</small></p>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace leftover link to hadoop.apache.org with ozone.apache.org.

https://issues.apache.org/jira/browse/HDDS-6006

## How was this patch tested?

```
hugo serve
open http://localhost:1313/release/1.1.0/
# verify "Documentation" link in the right
```