### PR TITLE
HDDS-6008. Remove leftover main menu definition

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,68 +18,6 @@ footnotereturnlinkcontents = "<sup>^</sup>"
 uglyurls = false
 baseUrl = "/"
 
-[[menu.main]]
-  name = "Download"
-  url = "releases.html"
-  weight = 1
-
-
-[[menu.main]]
-  name = "Documentation"
-  identifier = "documentation"
-  weight = 2
-
-[[menu.main]]
-   name = "Latest"
-   parent = "documentation"
-   url = "https://hadoop.apache.org/docs/current/"
-
-[[menu.main]]
-   name = "Stable"
-   parent = "documentation"
-   url = "https://hadoop.apache.org/docs/stable/"
-
-
-
-
-[[menu.main]]
-   name = "Community"
-   identifier = "community"
-   weight = 3
-
-
-
-[[menu.main]]
-   name = "Development"
-   identifier = "development"
-   weight = 4
-
-[[menu.main]]
-  name = "How to Contribute"
-  url = "https://wiki.apache.org/hadoop/HowToContribute"
-  parent = "development"
-
-[[menu.main]]
-   name = "Help"
-   identifier = "help"
-   weight = 5
-
-[[menu.main]]
-   name = "Buy Stuff"
-   url = "https://www.cafepress.com/hadoop"
-   parent = "help"
-
-[[menu.main]]
-   name = "Sponsorshop"
-   url = "https://www.apache.org/foundation/sponsorship.html"
-   parent = "help"
-
-[[menu.main]]
-   name = "Thanks"
-   url = "https://www.apache.org/foundation/thanks.html"
-   parent = "help"
-
-
 # Configure the English version of the website.
 [languages.en]
   languageCode = "en-us"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -62,7 +62,7 @@
         <div class="container">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
-                        data-target="#ratis-menu" aria-expanded="false">
+                        data-target="#ozone-menu" aria-expanded="false">
                     <span class="sr-only">Toggle navigation</span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
@@ -70,7 +70,7 @@
                 </button>
             </div>
 
-            <div id="ratis-menu" class="collapse navbar-collapse">
+            <div id="ozone-menu" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav navbar-right">
                     <li><a href="faq">FAQ</a></li>
                     <li><a href="downloads">Download</a></li>


### PR DESCRIPTION
## What changes were proposed in this pull request?

> A menu is a named array of menu entries accessible by name via the `.Site.Menus` site variable. For example, you can access your site’s `main` menu via `.Site.Menus.main`.

Ozone website defines `menu.main` in `config.toml`, but does not access it, nor do the menu items appear in the generated `asf-site` branch.  Thus I think we can remove this menu definition leftover from Hadoop.

Also rename `div id` leftover from Ratis.

https://issues.apache.org/jira/browse/HDDS-6008

## How was this patch tested?

```
hugo serve
open http://localhost:1313
```