### PR TITLE
HDDS-6007. Replace closer.cgi links with CDN

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -20,7 +20,7 @@ type: custompage
 ## To verify Apache Ozone releases using GPG:
 
 1.  Download the release ozone-X.Y.Z-src.tar.gz from a [mirror
-    site](https://www.apache.org/dyn/closer.cgi/ozone).
+    site](https://dlcdn.apache.org/ozone).
 2.  Download the signature file ozone-X.Y.Z-src.tar.gz.asc from
     [Apache](https://downloads.apache.org/ozone/).
 3.  Download the Ozone [KEYS](https://downloads.apache.org/ozone/KEYS)
@@ -31,7 +31,7 @@ type: custompage
 ## To perform a quick check using SHA-512:
 
 1.  Download the release ozone-X.Y.Z-src.tar.gz from a [mirror
-    site](https://www.apache.org/dyn/closer.cgi/hadoop/ozone).
+    site](https://dlcdn.apache.org/ozone).
 2.  Download the checksum ozone-X.Y.Z-src.tar.gz.sha512 from
     [Apache](https://downloads.apache.org/ozone/).
 3.  `sha512sum -c ozone-X.Y.Z-src.tar.gz`

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -37,12 +37,12 @@
        <td>{{dateFormat "2006 Jan 2 " .Date}}</td>
        {{ if eq .Params.hadoop true }}
          <td>
-           <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
+           <a href="https://dlcdn.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
            (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
            <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
           </td>
           <td>
-            <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
+            <a href="https://dlcdn.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
             (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
             <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
            </td>
@@ -51,12 +51,12 @@
            </td>
        {{else}}
          <td>
-           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
+           <a href="https://dlcdn.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
            (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
            <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
          </td>
          <td>
-           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
+           <a href="https://dlcdn.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
            (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
            <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
          </td>

--- a/layouts/release/single.html
+++ b/layouts/release/single.html
@@ -21,14 +21,14 @@
 <div class="col-md-4" style="padding: 20px;">
     {{ if eq .Params.hadoop true }}
        <p>
-           <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz"
+           <a href="https://dlcdn.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz"
               class="btn btn-success">Download tar.gz</a></p>
        <p>
            (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
            <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
        </p>
        <p>
-           <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz"
+           <a href="https://dlcdn.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz"
               class="btn btn-warning">Download src</a></p>
        <p>
            (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
@@ -38,14 +38,14 @@
        </p>
     {{else}}
        <p>
-           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz"
+           <a href="https://dlcdn.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz"
               class="btn btn-success">Download tar.gz</a></p>
        <p>
            (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
            <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
        </p>
        <p>
-           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz"
+           <a href="https://dlcdn.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz"
               class="btn btn-warning">Download src</a></p>
        <p>
            (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace links to `closer.cgi` with direct links to Apache CDN (dlcdn.apache.org).

https://issues.apache.org/jira/browse/HDDS-6007

## How was this patch tested?

Verified links from the downloads page:

```
$ for url in \
    https://dlcdn.apache.org/ozone/1.2.0/ozone-1.2.0-src.tar.gz \
    https://dlcdn.apache.org/ozone/1.2.0/ozone-1.2.0.tar.gz \
    https://dlcdn.apache.org/ozone/1.1.0/ozone-1.1.0-src.tar.gz \
    https://dlcdn.apache.org/ozone/1.1.0/ozone-1.1.0.tar.gz \
    https://dlcdn.apache.org/hadoop/ozone/ozone-1.0.0/hadoop-ozone-1.0.0-src.tar.gz \
    https://dlcdn.apache.org/hadoop/ozone/ozone-1.0.0/hadoop-ozone-1.0.0.tar.gz \
    https://dlcdn.apache.org/hadoop/ozone/ozone-0.5.0-beta/hadoop-ozone-0.5.0-beta-src.tar.gz \
    https://dlcdn.apache.org/hadoop/ozone/ozone-0.5.0-beta/hadoop-ozone-0.5.0-beta.tar.gz; do
  curl --insecure --head -Ss $url | head -1
done
HTTP/2 200
HTTP/2 200
HTTP/2 200
HTTP/2 200
HTTP/2 200
HTTP/2 200
HTTP/2 200
HTTP/2 200
```