### PR TITLE
HDDS-6013. Fix Documentation button for release pages.

### DIFF
--- a/layouts/release/single.html
+++ b/layouts/release/single.html
@@ -51,7 +51,7 @@
            (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
            <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
        </p>
-       <p><a href="https://hadoop.apache.org/ozone/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
+       <p><a href="https://ozone.apache.org/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
        </p>
     {{end}}
     <p><small>{{dateFormat "2006 Jan 2 " .Date}}</small></p>


### PR DESCRIPTION
Fix documentation button for release pages. See [HDDS-6013](https://issues.apache.org/jira/browse/HDDS-6013) for details.

Tested locally with Hugo on the release pages for 1.2.0, 1.1.0 (post hadoop) and 1.0.0 (still part of hadoop). The button worked on all these pages.