### PR TITLE
HDDS-6136. Update Ozone site release page for 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public
 hugo
+.hugo_build.lock

--- a/content/release/1.2.1.md
+++ b/content/release/1.2.1.md
@@ -1,7 +1,9 @@
 ---
-title: Release 1.2.0 available
-date: 2021-11-17
+title: Release 1.2.1 available
+date: 2021-12-22
 linked: true
+aliases:
+    - /release/1.2.0
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +21,7 @@ linked: true
 
 ![glacier-haiku](releases/1.2.0.jpg)
 
-Apache Ozone 1.2.0 is released with following features:
+Apache Ozone 1.2.1 is released with following features:
 
 - Non-rolling downgrade support to 1.1.0
 - Storage Container Manager high availability for new clusters

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,7 +25,7 @@
             </p>
             </p>
             <p></p>
-            <p class="lead">Ozone is now Generally Available(GA) with <a href="release/1.2.0/">1.2.0</a> release.
+            <p class="lead">Ozone is now Generally Available(GA) with <a href="release/1.2.1/">1.2.1</a> release.
             </p>
             <p></p>
         </div>


### PR DESCRIPTION
Replace references to 1.2.0 on the website with 1.2.1. https://ozone.apache.org/release/1.2.0/ should now redirect to https://ozone.apache.org/release/1.2.1.

If we want to leave 1.2.0 on the website and simply add 1.2.1 like a normal release, I can modify the PR to do this instead.

Page content and redirect tested locally with `hugo serve`.