### PR TITLE
HDDS-7359. Remove Ozone 0.5.0-beta download link from the website

### DIFF
--- a/content/release/0.5.0-beta.md
+++ b/content/release/0.5.0-beta.md
@@ -1,7 +1,6 @@
 ---
 title: Release 0.5.0-beta available
 date: 2020-03-24
-linked: true
 hadoop: true
 ---
 <!---


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-7359

Tested locally with `hugo serve`. Verified that 0.5.0-beta row is gone from download page with this change.