### PR TITLE
HDDS-8523. Upgrade Github Actions runner to ubuntu-latest

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build:
     name: regenerate
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout branch with source
         uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 18.04 runners no longer exist on github, therefore it's needed to update them to a newer version version.