### PR TITLE
HDDS-8516. Remove link to documentation for old releases

### DIFF
--- a/content/release/0.2.1-alpha.md
+++ b/content/release/0.2.1-alpha.md
@@ -2,6 +2,7 @@
 title: Release 0.2.1-alpha available
 date: 2018-10-01
 hadoop: true
+supported: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/0.3.0-alpha.md
+++ b/content/release/0.3.0-alpha.md
@@ -2,6 +2,7 @@
 title: Release 0.3.0-alpha available
 date: 2018-11-22
 hadoop: true
+supported: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/0.4.0-alpha.md
+++ b/content/release/0.4.0-alpha.md
@@ -2,6 +2,7 @@
 title: Release 0.4.0-alpha available
 date: 2019-05-07
 hadoop: true
+supported: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/0.4.1-alpha.md
+++ b/content/release/0.4.1-alpha.md
@@ -2,6 +2,7 @@
 title: Release 0.4.1-alpha available
 date: 2019-10-13
 hadoop: true
+supported: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/0.5.0-beta.md
+++ b/content/release/0.5.0-beta.md
@@ -2,6 +2,7 @@
 title: Release 0.5.0-beta available
 date: 2020-03-24
 hadoop: true
+supported: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/layouts/release/single.html
+++ b/layouts/release/single.html
@@ -34,8 +34,10 @@
            (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
            <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
        </p>
-       <p><a href="https://hadoop.apache.org/ozone/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
+        {{ if ne .Params.supported false }}
+            <p><a href="https://hadoop.apache.org/ozone/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
        </p>
+        {{end}}
     {{else}}
        <p>
            <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz"
@@ -51,8 +53,10 @@
            (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
            <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
        </p>
-       <p><a href="https://ozone.apache.org/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
+        {{ if ne .Params.supported false }}
+            <p><a href="https://ozone.apache.org/docs/{{.File.BaseFileName }}" class="btn btn-primary">Documentation</a>
        </p>
+        {{end}}
     {{end}}
     <p><small>{{dateFormat "2006 Jan 2 " .Date}}</small></p>
 


### PR DESCRIPTION
Added the "supported" flag and filtering in single.html based on this flag for docs.
 