### PR TITLE
HDDS-7678. Link to the nightly doc on the Ozone website

### DIFF
--- a/layouts/custompage/docs.html
+++ b/layouts/custompage/docs.html
@@ -21,7 +21,7 @@ Choose a version:
 <p>
   <table class="table table-striped">
      <tr>
-       <td><a href="https://ci-hadoop.apache.org/view/Hadoop%20Ozone/job/ozone-doc-master/lastSuccessfulBuild/artifact/hadoop-hdds/docs/public/index.html">edge(master)</a></td>
+       <td><a href="/docs/edge/">edge (master)</a></td>
      </tr>
    {{range first 5 (where (where .Site.Pages "Section" "release") ".Params.linked" true) }}
      <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update the "edge" link on the Ozone website docs page to point to the content published on the website itself, instead of the one on Jenkins CI server.

https://issues.apache.org/jira/browse/HDDS-7678

## How was this patch tested?

`open https://ozone.apache.org/docs/edge/`