### PR TITLE
HDDS-9604. Support jira auto linking between github and ozone-site repo.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,6 +21,8 @@ github:
     squash:  true
     merge:   false
     rebase:  false
+  autolink_jira:
+    - HDDS
 notifications:
   commits:      commits@ozone.apache.org
   issues:       issues@ozone.apache.org


### PR DESCRIPTION
Update .asf.yaml according to ASF [docs](https://s.apache.org/asfyaml) to support auto-linking Jira issues when they are typed in a comment in this repo. For example, after this change HDDS-1234 would automatically be converted into a Jira link.

## Testing

According to https://gitbox.apache.org/schemes.cgi?ozone-site, the change will only take affect on the master branch, so I am not sure how to test it before merging.