### PR TITLE
HDDS-9573. Restore Matomo web analytics from the original website.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,6 +120,7 @@ const config = {
         darkTheme: darkCodeTheme,
       },
     }),
+    scripts: ['/script/matomo.js'],
 };
 
 module.exports = config;

--- a/static/script/matomo.js
+++ b/static/script/matomo.js
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var _paq = (window._paq = window._paq || []);
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+/* We explicitly disable cookie tracking to avoid privacy issues */
+_paq.push(['disableCookies']);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function () {
+  var u = 'https://analytics.apache.org/';
+  _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  _paq.push(['setSiteId', '34']);
+  var d = document,
+    g = d.createElement('script'),
+    s = d.getElementsByTagName('script')[0];
+  g.async = true;
+  g.src = u + 'matomo.js';
+  s.parentNode.insertBefore(g, s);
+})();


### PR DESCRIPTION
Add Matomo analytics to the new Docusaurus site. References are here:

[Matomo integration for the original Ozone website with Hugo](https://github.com/apache/ozone-site/pull/31/files)

[Example of integrating Matomo with a Docusaurus site from Apache Superset](https://github.com/apache/superset/pull/20398/files)

[Matomo Javascript client documentation](https://developer.matomo.org/guides/tracking-javascript-guide)

[ASF Matomo documentation](https://privacy.apache.org/matomo/)

I don't think we can test it until the new website is published.