### PR TITLE
HDDS-9563. Containerize website development server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+build
+.docusaurus
+.cache-loader
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See https://pnpm.io/docker
+
+ARG NODE_VERSION=20
+FROM node:${NODE_VERSION}-slim AS base
+# Creates store at /pnpm/store by default.
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+# Install dependencies to /ozone-site-deps/node_modules as part of the image.
+WORKDIR /ozone-site
+COPY package.json .
+COPY pnpm-lock.yaml .
+# ERROR: Complains about peer dependencies.
+RUN pnpm install --frozen-lockfile
+# RUN pnpm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,9 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
-# Install dependencies to /ozone-site-deps/node_modules as part of the image.
+# Install dependencies to /ozone-site/node_modules as part of the image.
 WORKDIR /ozone-site
 COPY package.json .
 COPY pnpm-lock.yaml .
-# ERROR: Complains about peer dependencies.
+# Lockfile should not be changed when installing dependencies, hence freezing it.
 RUN pnpm install --frozen-lockfile
-# RUN pnpm install

--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ Once installed, there are two ways to preview the website locally. Each option w
 
   2. Run `pnpm serve` to preview the built website locally.
 
+- **Containerized Build (Recommended)**: This is the easiest way to preview the website and the easiest for any developer who would want to contribute to the project.
+**Prerequisites**:
+  
+  - Docker
+  - Docker Compose
+
+  The project has included `Dockerfile` and `compose.yml` files to build and run the website in a containerized environment.
+
+    1. Make sure the current repository is the working directory.
+        - Default port is mapped to **3000**. Make changes accordingly if this is already being used in the local machine.
+    2. Run `docker-compose up`.
+    3. Preview for the website will be available at `localhost:3000`
+
+  Any changes made in the repository will be reflected in the preview. No extra installation required.
+
+
+
+
 ### Updating the Website
 
 The following files can be modified to change various aspects of the website:

--- a/README.md
+++ b/README.md
@@ -34,43 +34,49 @@ Welcome to the development branch of the new and improved Apache Ozone website. 
 
 ## Local Development
 
-### Setup
+Docusaurus supports previewing the website locally. Below are various options to launch a preview of the site at `localhost:3000` on your machine.
+
+### Option 1: Docker (Recommended)
+
+The project includes a `Dockerfile` and a `compose.yml` file to build and run the website in a containerized environment. This creates a docker image called `ozone-site-dev` with all the dependencies included, and uses it to run the [Docusaurus development server](https://docusaurus.io/docs/installation#running-the-development-server).
+
+1. Install [docker](https://docs.docker.com/engine/install/).
+
+2. Install [docker compose](https://docs.docker.com/compose/install/).
+
+3. Run `docker compose up` from the repository root.
+
+4. Preview the website at `localhost:3000` in your browser.
+
+  - Any changes made in the repository will be reflected in the preview.
+
+5. Press `Ctrl+C` or run `docker compose down` to stop the preview.
+
+### Option 2: pnpm
+
+Build and run the website locally with the `pnpm` package manager.
 
 1. Install [pnpm](https://pnpm.io/installation), which will be used to build the site.
 
 2. Install dependencies required to build the website by running `pnpm install` at the website root.
 
-### Preview
-
-Once installed, there are two ways to preview the website locally. Each option will launch the site at `localhost:3000` on your machine.
-
-- **Development Server** (See [Docusaurus docs](https://docusaurus.io/docs/installation#running-the-development-server)): This option will start the Docusaurus development server. It will not produce a `build` directory with build artifacts, and allows updates to website files to be displayed in the browser in real time.
+- [**Development Server**](https://docusaurus.io/docs/installation#running-the-development-server): This option will start the Docusaurus development server, which allows updates to website files to be displayed in the browser in real time. It will not produce a `build` directory with build artifacts.
 
   1. Run `pnpm start` from the repository root to start the development server.
 
-- **Local Build** (See [Docusaurus docs](https://docusaurus.io/docs/installation#build)): This option will do a production build, putting artifacts in the `build` directory. This can still be previewed locally, but will not automatically reflect changes to website files.
+  2. Preview the website at `localhost:3000` in your browser.
+
+  3. Press `Ctrl+C` to stop the preview.
+
+- [**Local Build**](https://docusaurus.io/docs/installation#build): This option will do a production build, putting artifacts in the `build` directory. This can still be previewed locally, but will not automatically reflect changes to website files.
 
   1. Run `pnpm build` from the repository root to build the content.
 
   2. Run `pnpm serve` to preview the built website locally.
 
-- **Containerized Build (Recommended)**: This is the easiest way to preview the website and the easiest for any developer who would want to contribute to the project.
-**Prerequisites**:
-  
-  - Docker
-  - Docker Compose
+  3. Preview the website at `localhost:3000` in your browser.
 
-  The project has included `Dockerfile` and `compose.yml` files to build and run the website in a containerized environment.
-
-    1. Make sure the current repository is the working directory.
-        - Default port is mapped to **3000**. Make changes accordingly if this is already being used in the local machine.
-    2. Run `docker-compose up`.
-    3. Preview for the website will be available at `localhost:3000`
-
-  Any changes made in the repository will be reflected in the preview. No extra installation required.
-
-
-
+  4. Press `Ctrl+C` to stop the preview.
 
 ### Updating the Website
 

--- a/compose.yml
+++ b/compose.yml
@@ -23,9 +23,9 @@ services:
       - 3000:3000
     volumes:
       - ".:/ozone-site"
-      # The below option is used to prevent overwriting of the docker image
-      # node_modules by the mounted volume's node_modules
-      # This would create an empty node_modules in the working directory of the local machine if not already present.
+      # The below option is used to prevent overwriting the node_modules directory in the docker image
+      # with the node_modules present in the mounted volume.
+      # This will create an empty node_modules directory in the working directory of the host if it is not already present.
       - /ozone-site/node_modules/
     working_dir: "/ozone-site"
     command: pnpm start --host '0.0.0.0'

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3"
+
+services:
+  site:
+    build: "."
+    image: "ozone-site-dev"
+    ports:
+      - "3000:3000"
+    volumes:
+      - ".:/ozone-site"
+      - /ozone-site/node_modules/
+    working_dir: "/ozone-site"
+    command: sh -c "pnpm start --host '0.0.0.0'"

--- a/compose.yml
+++ b/compose.yml
@@ -25,7 +25,7 @@ services:
       - ".:/ozone-site"
       # The below option is used to prevent overwriting of the docker image
       # node_modules by the mounted volume's node_modules
-      # This would create an empty node_modules in the working directory of the local machine
+      # This would create an empty node_modules in the working directory of the local machine if not already present.
       - /ozone-site/node_modules/
     working_dir: "/ozone-site"
     command: pnpm start --host '0.0.0.0'

--- a/compose.yml
+++ b/compose.yml
@@ -20,9 +20,12 @@ services:
     build: "."
     image: "ozone-site-dev"
     ports:
-      - "3000:3000"
+      - 3000:3000
     volumes:
       - ".:/ozone-site"
+      # The below option is used to prevent overwriting of the docker image
+      # node_modules by the mounted volume's node_modules
+      # This would create an empty node_modules in the working directory of the local machine
       - /ozone-site/node_modules/
     working_dir: "/ozone-site"
-    command: sh -c "pnpm start --host '0.0.0.0'"
+    command: pnpm start --host '0.0.0.0'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@7.33.6",
+  "packageManager": "pnpm@8.7.1",
   "name": "doc-site",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
This PR adds the required changes for creation of a docker file, which anybody can run with docker-compose and check changes on the go.
No package installations required.

#### What will this PR will do?
- It will build an image with the node_modules already installed in it.
- `docker-compose up` will create a container with the local changes mounted on this container.
- Site will be available to view on `localhost:3000` (default port mapping in the container)

#### What this means for the end-user?
- While the site can be deployed without an image needing to be built, as discussed in the [JIRA](https://issues.apache.org/jira/browse/HDDS-9563), we can make the developer work much smoother with a containerized environment
- Any new contributor can just simply spin up a container from the image, and make changes in their local development directory
- These changes will be picked up by the container in the mounted volume and live changes will be visible on localhost:3000 