### PR TITLE
HDDS-9926. Publish WIP website to staging branch (2/2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           # Delete previous build from the branch, but preserve files with necessary metadata.
           mv README.md .asf.yaml .git /tmp
-          rm -rf * .*
+          rm -rf $(ls -A)
           mv /tmp/README.md /tmp/.asf.yaml /tmp/.git .
 
           # Commit new build to the branch.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,11 +46,11 @@ jobs:
       - name: "Commit changes"
         working-directory: 'publish'
         run: |
-            echo "Deleting previous build from the branch ${{ github.ref_name }}
+            echo "Deleting previous build from the branch $(git branch --show-current)"
             # Skips removing the .git folder so that we still have branch tracking information.
             rm -rf *
 
-            echo "Committing new build to the branch ${{ github.ref_name }}"
+            echo "Committing new build to the branch $(git branch --show-current)"
             cp -R ../src/build/. .
             git config --global user.name 'Github Actions'
             git config --global user.email 'noreply@github.com'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,20 +28,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Check out the website source in the current working directory.
       - name: "Checkout source branch"
         uses: actions/checkout@v3
-        # with:
-        #   path: './ozone-site-src'
-      - name: "Build Website"
-        # working-directory: './ozone-site-src'
-        # Website source is mounted as volume, so the build output ends up in ./build outside of the container.
-        run: |
-          docker compose run site pnpm run build
       - name: "Checkout build branch"
         uses: actions/checkout@v3
         with:
           path: './build'
           ref: 'asf-site-v2'
+      - name: "Build Website"
+        # Website source is mounted as volume, so the build output ends up in ./build outside of the container.
+        # This overwrites all files from the initial asf-site-v2 branch checkout, so we can just commit the result of this command.
+        run: |
+          docker compose run site pnpm run build
       - name: "Commit changes"
         working-directory: './build'
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           path: 'src'
       - name: "Build website"
+        working-directory: 'src'
         # Website source is mounted as volume, so the build output ends up in ./src/build outside of the container.
         run: |
           docker compose run site pnpm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ on:
     branches:
       # TODO update this to master when the new website is ready to be published.
       - HDDS-9225-website-v2
+      - publish-changes
 
 jobs:
   build:
@@ -41,21 +42,21 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: 'publish'
-          ref: 'asf-site-v2'
+          ref: 'asf-site-v2-test'
       - name: "Commit changes"
         working-directory: 'publish'
         run: |
-            # Delete previous build from the branch.
-            # Skips removing the .git folder so that we still have branch tracking information.
-            # Skips removing .asf.yaml which has auto-publishing information.
-            rm -rf *
+          # Delete previous build from the branch, but preserve files with necessary metadata.
+          mv README.md .asf.yaml .git /tmp
+          rm -rf * .*
+          mv /tmp/README.md /tmp/.asf.yaml /tmp/.git .
 
-            # Commit new build to the branch.
-            cp -R ../src/build/. .
-            git config --global user.name 'Github Actions'
-            git config --global user.email 'noreply@github.com'
-            git add .
-            git commit -a -m "[auto] Apply changes from $GITHUB_REF_NAME $GITHUB_SHA" || true
-            git push
+          # Commit new build to the branch.
+          cp -R ../src/build/. .
+          git config --global user.name 'Github Actions'
+          git config --global user.email 'noreply@github.com'
+          git add .
+          git commit -a -m "[auto] Apply changes from $GITHUB_REF_NAME $GITHUB_SHA" || true
+          git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,8 @@ name: "auto-build-website-v2"
 on:
   push:
     branches:
-      - HDDS-9225-website-v2
+      # - HDDS-9225-website-v2
+      - publish-staging
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,13 +46,12 @@ jobs:
       - name: "Commit changes"
         working-directory: 'publish'
         run: |
-            echo "Deleting previous build from the branch $GITHUB_REF_NAME"
-            mv .git /tmp
+            echo "Deleting previous build from the branch ${{ github.ref_name }}
+            # Skips removing the .git folder so that we still have branch tracking information.
             rm -rf *
-            mv /tmp/.git .
 
-            echo "Committing new build to the branch $GITHUB_REF_NAME"
-            cp -R ../src/build/ .
+            echo "Committing new build to the branch ${{ github.ref_name }}"
+            cp -R ../src/build/. .
             git config --global user.name 'Github Actions'
             git config --global user.email 'noreply@github.com'
             git add .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ on:
     branches:
       # TODO update this to master when the new website is ready to be published.
       - HDDS-9225-website-v2
-      - publish-changes
+      - publish-staging
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build Ozone website v2 and commit it to a staging branch.
+# This will be picked up by configurations in .asf.yml to publish it to a staging domain.
+
+name: "auto-build-website-v2"
+
+on:
+  push:
+    branches:
+      - HDDS-9225-website-v2
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout source branch"
+        uses: actions/checkout@v3
+        # with:
+        #   path: './ozone-site-src'
+      - name: "Build Website"
+        # working-directory: './ozone-site-src'
+        # Website source is mounted as volume, so the build output ends up in ./build outside of the container.
+        run: |
+          docker compose run site pnpm run build
+      - name: "Checkout build branch"
+        uses: actions/checkout@v3
+        with:
+          path: './build'
+          ref: 'asf-site-v2'
+      - name: "Commit changes"
+        working-directory: './build'
+        run: |
+            git config --global user.name 'Github Actions'
+            git config --global user.email 'noreply@github.com'
+            git add .
+            git commit -a -m "[auto] Apply changes from HDDS-9225-website-v2 $GITHUB_SHA" || true
+            git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ on:
     branches:
       # TODO update this to master when the new website is ready to be published.
       - HDDS-9225-website-v2
-      - publish-staging
 
 jobs:
   build:
@@ -42,7 +41,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: 'publish'
-          ref: 'asf-site-v2-test'
+          # TODO update this to asf-site when the website is ready to be published.
+          ref: 'asf-site-v2'
       - name: "Commit changes"
         working-directory: 'publish'
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,25 +29,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check out the website source in the current working directory.
-      - name: "Checkout source branch"
-        uses: actions/checkout@v3
-      - name: "Checkout build branch"
+      - name: "Checkout source branch ${{ github.ref_name }}"
         uses: actions/checkout@v3
         with:
-          path: './build'
-          ref: 'asf-site-v2'
-      - name: "Build Website"
-        # Website source is mounted as volume, so the build output ends up in ./build outside of the container.
-        # This overwrites all files from the initial asf-site-v2 branch checkout, so we can just commit the result of this command.
+          path: 'src'
+      - name: "Build website"
+        # Website source is mounted as volume, so the build output ends up in ./src/build outside of the container.
         run: |
           docker compose run site pnpm run build
+      - name: "Checkout publish branch"
+        uses: actions/checkout@v3
+        with:
+          path: 'publish'
+          ref: 'asf-site-v2'
       - name: "Commit changes"
-        working-directory: './build'
+        working-directory: 'publish'
         run: |
+            echo "Deleting previous build from the branch $GITHUB_REF_NAME"
+            mv .git /tmp
+            rm -rf *
+            mv /tmp/.git .
+
+            echo "Committing new build to the branch $GITHUB_REF_NAME"
+            cp -R ../src/build/ .
             git config --global user.name 'Github Actions'
             git config --global user.email 'noreply@github.com'
             git add .
-            git commit -a -m "[auto] Apply changes from HDDS-9225-website-v2 $GITHUB_SHA" || true
+            git commit -a -m "[auto] Apply changes from $GITHUB_REF_NAME $GITHUB_SHA" || true
             git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,14 +15,13 @@
 
 # Build Ozone website v2 and commit it to a staging branch.
 # This will be picked up by configurations in .asf.yml to publish it to a staging domain.
-
-name: "auto-build-website-v2"
+name: "auto-publish-website-v2"
 
 on:
   push:
     branches:
-      # - HDDS-9225-website-v2
-      - publish-staging
+      # TODO update this to master when the new website is ready to be published.
+      - HDDS-9225-website-v2
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,11 +46,12 @@ jobs:
       - name: "Commit changes"
         working-directory: 'publish'
         run: |
-            echo "Deleting previous build from the branch $(git branch --show-current)"
+            # Delete previous build from the branch.
             # Skips removing the .git folder so that we still have branch tracking information.
+            # Skips removing .asf.yaml which has auto-publishing information.
             rm -rf *
 
-            echo "Committing new build to the branch $(git branch --show-current)"
+            # Commit new build to the branch.
             cp -R ../src/build/. .
             git config --global user.name 'Github Actions'
             git config --global user.email 'noreply@github.com'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
 
 Welcome to the development branch of the new and improved Apache Ozone website. The new site is being built with [Docusaurus](https://docusaurus.io/). See the [Docusaurus docs](https://docusaurus.io/docs) for details on working with this framework.
 
-## Relevant Links
+You can preview the current state of the new website at https://ozone-site-v2.staged.apache.org.
+
+## Context
 
 - [HDDS-9225](https://issues.apache.org/jira/browse/HDDS-9225) is the parent Jira tracking current tasks required to get the new website ready for deployment.
 


### PR DESCRIPTION
Part 2/2. Requires #55 

Add github actions workflow to automatically build changes to the website v2 branch and commit the build artifacts to a staging branch. From here they can be published to a staging domain by the changes in #55.

## Testing

Github actions workflow to build and commit the website was tested on my fork. It successfully built the site and committed to the specified branch. See [this commit](https://github.com/errose28/ozone-site/actions/runs/7218001805/job/19666723869) which pushed [these changes](https://github.com/errose28/ozone-site/commit/20d1f31fac0ede410e310c9c0348ccb7844554e9) to my test branch