### PR TITLE
HDDS-10199. Node.js 16 actions are deprecated

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch with source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Checkout branch with rendered version
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: public
           ref: asf-site


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade GitHub actions to `v4` to get Node.js 20.

https://issues.apache.org/jira/browse/HDDS-10199