### PR TITLE
HDDS-10203. Update Github actions to v4 since Node.js 16 actions are deprecated.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Check out the website source in the current working directory.
       - name: "Checkout source branch ${{ github.ref_name }}"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'src'
       - name: "Build website"
@@ -38,7 +38,7 @@ jobs:
         run: |
           docker compose run site pnpm run build
       - name: "Checkout publish branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'publish'
           # TODO update this to asf-site when the website is ready to be published.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ on:
     branches:
       # TODO update this to master when the new website is ready to be published.
       - HDDS-9225-website-v2
+      - update-actions
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ on:
     branches:
       # TODO update this to master when the new website is ready to be published.
       - HDDS-9225-website-v2
-      - update-actions
 
 jobs:
   build:


### PR DESCRIPTION
Update the checkout action to v4 since this supports node 20. Similar to #59 but for the new website feature branch.

HDDS-10203

## Testing

Verified a test build of the site [succeeds on my fork](https://github.com/errose28/ozone-site/actions/runs/7645982361/job/20833793107).