### PR TITLE
HDDS-10266. Auto label PRs for the new website.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+website-v2:
+  - base-branch: HDDS-9225-website-v2

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Configuration for .github/workflows/label-pr.yml
 # This workflow and its configuration can be deleted once the website's feature branch is merged.
 website-v2:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,4 @@
+# Configuration for .github/workflows/label-pr.yml
+# This workflow and its configuration can be deleted once the website's feature branch is merged.
 website-v2:
   - base-branch: HDDS-9225-website-v2

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This workflow reads its configuration from the .github/labeler.yml file.
 # This workflow and its configuration can be deleted once the website's feature branch is merged.
 name: "Pull Request Labeler"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,3 +1,5 @@
+# This workflow reads its configuration from the .github/labeler.yml file.
+# This workflow and its configuration can be deleted once the website's feature branch is merged.
 name: "Pull Request Labeler"
 on:
 - pull_request_target
@@ -10,4 +12,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v5
-

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+


### PR DESCRIPTION
## Summary

Use https://github.com/actions/labeler to automatically label pull requests targeting the `HDDS-9225-website-v2` branch with the `website-v2` label. I kept forgetting to do it manually.

## Jira

HDDS-10266

## Testing

According to the [docs](https://github.com/actions/labeler?tab=readme-ov-file#initial-set-up-of-the-labeler-action) we can't test the change directly until merging it to the target branch (I added the `website-v2` label to the PR manually). However, I did set up a [mocked version in my fork](https://github.com/errose28/ozone-site/pull/1) that looks like it worked.
- The [labeler-test](https://github.com/errose28/ozone-site/tree/labeler-test) branch has the configuration committed
- A [PR](https://github.com/errose28/ozone-site/pull/1) against that branch had the `test-label` applied.