### PR TITLE
HDDS-9603. Add PR title check for ozone-site repo.

### DIFF
--- a/.github/scripts/pr_title_check.sh
+++ b/.github/scripts/pr_title_check.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TITLE=$1
+
+assertMatch() {
+    echo "${TITLE}" | grep -E "$1" >/dev/null
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        echo $2
+        exit 1
+    fi
+}
+
+assertNotMatch() {
+    echo "${TITLE}" | grep -E -v "$1" >/dev/null
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        echo $2
+        exit 1
+    fi
+}
+
+# strip starting 'Revert "', if any
+TITLE=${TITLE#Revert \"}
+if [ "$1" != "${TITLE}" ]; then
+  echo "Leading 'Revert \"' in the PR title has been stripped solely for this title checking purpose. Performing actual title check on:"
+  echo "${TITLE}"
+fi
+
+assertMatch    '^HDDS'                             'Fail: must start with HDDS'
+assertMatch    '^HDDS-'                            'Fail: missing dash in Jira'
+assertNotMatch '^HDDS-0'                           'Fail: leading zero in Jira'
+assertMatch    '^HDDS-[1-9][0-9]{0,4}[^0-9]'       'Fail: Jira must be 1 to 5 digits'
+assertMatch    '^HDDS-[1-9][0-9]{0,4}\.'           'Fail: missing dot after Jira'
+assertMatch    '^HDDS-[1-9][0-9]{0,4}\. '          'Fail: missing space after Jira'
+assertNotMatch '[[:space:]]$'                      'Fail: trailing space'
+assertNotMatch '\.{3,}$'                           'Fail: trailing ellipsis indicates title is cut'
+assertNotMatch '…$'                                'Fail: trailing ellipsis indicates title is cut'
+assertNotMatch '[[:space:]]{2}'                    'Fail: two consecutive spaces'
+assertMatch    '^HDDS-[1-9][0-9]{0,4}\. .*[^ ]$'   'Fail: not match "^HDDS-[1-9][0-9]{0,4}\. .*[^ ]$"'
+
+echo 'OK'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: pull request
+
+on:
+  pull_request:
+    types:
+      - reopened
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Check pull request title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run:
+          .github/scripts/pr_title_check.sh "${TITLE}"
+


### PR DESCRIPTION
## Summary

Copy the PR title check script and Github Action from the main Ozone repo to the new website.

I've left this in a separate file from the PR labeler in #68 since we might want to cherry pick this commit back to the main website development branch. Alternatively we could put both checks into the pull-request workflow.

## Jira

HDDS-9603

## Testing

- A [test PR](https://github.com/errose28/ozone-site/pull/2) on my fork failed the title check.

- I did not copy the bats tests since we would have to add a CI workflow for that here as well and manage the dependency which seems like overkill for a simple script that is already verified to work, but I'm open to suggestions here.