### PR TITLE
HDDS-9568. Add docusaurus build check in github actions

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: docusaurus
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  push:
+
+concurrency:
+  group: docusaurus-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: |
+          docker build -t ozone-site:ci .
+      - name: Install dependencies
+        run: |
+          docker run --rm -v $PWD:/ozone-site ozone-site:ci pnpm install
+      - name: Run test
+        run: |
+          docker run --rm -v $PWD:/ozone-site ozone-site:ci pnpm build
+

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -34,11 +34,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build Docker image
         run: |
-          docker build -t ozone-site:ci .
-      - name: Install dependencies
-        run: |
-          docker run --rm -v $PWD:/ozone-site ozone-site:ci pnpm install
+          docker compose build
       - name: Run test
         run: |
-          docker run --rm -v $PWD:/ozone-site ozone-site:ci pnpm build
-
+          docker compose run site pnpm build


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add smoketest that builds the website in CI.

https://issues.apache.org/jira/browse/HDDS-9568

## How was this patch tested?

Introduced broken link, verified the same steps fail with:

```
Error: Unable to build website for locale en.
...
  [cause]: Error: Docusaurus found broken links!
...
  - On source page path = /docs/system-internals/features/ratis-streaming:
     -> linking to ./no-such-page (resolved as: /docs/system-internals/features/no-such-page)
...
```

CI:
https://github.com/adoroszlai/ozone-site/actions/runs/7740784527/job/21106463270