### PR TITLE
HDDS-10337. Fix social media preview.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,8 +11,10 @@ const config = {
   tagline: 'Scalable, redundant, distributed storage system optimized for data analytics and object store workloads',
   favicon: 'img/favicon/favicon.ico',
 
-  // Set the production url of your site here
-  url: 'https://ozone.apache.org',
+  // Set the production URL of the website. Must be updated when the final site is deployed.
+  // This must match the URL the website is hosted at for social media previews to work.
+  // If you are testing the social media image (themeConfig.image) locally, set this to http://localhost:3000.
+  url: 'https://ozone-site-v2.staged.apache.org',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
@@ -20,9 +22,9 @@ const config = {
   // Fail the build if there are any broken links.
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
+  onBrokenAnchors: 'throw',
   // Fail the build if multiple pages map to the same URL.
   onDuplicateRoutes: 'throw',
-  onBrokenAnchors: 'throw',
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,13 +8,14 @@ const darkCodeTheme = themes.dracula;
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Apache Ozone',
-  tagline: 'Scalable, redundant, distributed storage system optimized for data analytics and object store workloads',
+  tagline: 'Scalable, redundant, distributed storage system optimized for data analytics and object store workloads.',
   favicon: 'img/favicon/favicon.ico',
 
   // Set the production URL of the website. Must be updated when the final site is deployed.
   // This must match the URL the website is hosted at for social media previews to work.
   // If you are testing the social media image (themeConfig.image) locally, set this to http://localhost:3000.
-  url: 'https://ozone-site-v2.staged.apache.org',
+  // url: 'https://ozone-site-v2.staged.apache.org',
+  url: 'http://localhost:3000',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,8 +14,7 @@ const config = {
   // Set the production URL of the website. Must be updated when the final site is deployed.
   // This must match the URL the website is hosted at for social media previews to work.
   // If you are testing the social media image (themeConfig.image) locally, set this to http://localhost:3000.
-  // url: 'https://ozone-site-v2.staged.apache.org',
-  url: 'http://localhost:3000',
+  url: 'https://ozone-site-v2.staged.apache.org',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,8 +8,8 @@ export default function Home() {
   const getStartedHref = `docs/quick-start/installation/docker`
   return (
     <Layout
-      title={`Welcome to ${siteConfig.title}`}
-      description="{siteConfig.tagline}">
+      title="Home"
+      description={`${siteConfig.tagline}`}>
           <div class="hero">
             <div class="container">
               <div class="row" style={{alignItems: 'center'}}>


### PR DESCRIPTION
## Description

After [HDDS-9564](https://issues.apache.org/jira/browse/HDDS-9564) was merged, the social media preview on the staging site was still broken. The image would not show up and the website's tagline was not displayed.

The social card was not displayed because the path to retrieve it is built from the `url` key in the docusaurus config, which was incorrectly set to `https://ozone.apache.org` instead of `https://ozone-site-v2.staged.apache.org` which did not match the staging domain the site is being hosted at.

The tagline was not displayed due to incorrect javascript formatting in the homepage.

See also HDDS-10313 to replace "redundant" with "reliable" which we can do after this is merged.

## Jira

HDDS-100337

## Testing

Modified the `url` config to http://localhost:300 and used [this browser plugin](https://chromewebstore.google.com/detail/social-media-link-preview/dlmoajpiphhokgbbfaiiekhlgpjnjfei) to test the preview. It looks like this:
![Screenshot 2024-02-08 at 2 27 25 PM](https://github.com/apache/ozone-site/assets/33912936/dbb32af7-3c4f-4e76-babc-28dc72352d09)
`localhost` in this image will be replaced with the website's staging domain when this is deployed.
