### PR TITLE
HDDS-10352. Add GitHub Actions workflow to build and run the website.

### DIFF
--- a/.github/scripts/curl.sh
+++ b/.github/scripts/curl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+echo 'Running website and checking homepage...'
+docker compose run --detach --service-ports site pnpm serve
+while [ "$(curl -so /dev/null -w '%{http_code}' http://localhost:3000)" != 200 ]; do
+  sleep 1;
+done
+echo 'Website homepage is responsive.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# See https://pnpm.io/docker
+name: ci
 
-ARG NODE_VERSION=20
-FROM node:${NODE_VERSION}-slim AS base
-# Creates store at /pnpm/store by default.
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+  push:
 
-# Install dependencies to /ozone-site/node_modules as part of the image.
-WORKDIR /ozone-site
-COPY package.json .
-COPY pnpm-lock.yaml .
-# --frozen-lockfile: pnpm-lock.yaml is expected to match constraints in package.json. Fail if it does not.
-# --prod: Do not install dev dependencies. The image is only used for running the website.
-RUN pnpm install --prod --frozen-lockfile
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  docusaurus:
+    uses: ./.github/workflows/docusaurus.yml
+  publish:
+    needs: docusaurus
+    # Update this to master when the website is ready to be published.
+    if: ${{ github.event == 'push' && github.ref_name == 'HDDS-9225-website-v2' }}
+    uses: ./.github/workflows/publish.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The main CI workflow for the Apache Ozone website.
+
 name: ci
 
 on:

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -16,25 +16,90 @@
 name: docusaurus
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-  push:
+  workflow_call:
 
 concurrency:
   group: docusaurus-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  script_dir: .github/scripts
+  image_tar: ozone-site-image.tar
+
 jobs:
-  build:
+  build-image:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout project
-        uses: actions/checkout@v4
-      - name: Build Docker image
-        run: |
-          docker compose build
-      - name: Run test
-        run: |
-          docker compose run site pnpm build
+    - name: Checkout project
+      uses: actions/checkout@v4
+    - name: Check Docker image cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.image_tar }}
+        key: image-${{ hashFiles('Dockerfile', 'compose.yml', 'pnpm-lock.yaml') }}
+        lookup-only: true
+    - name: Build Docker image
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        docker compose build
+    - name: Save docker image to tar
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        docker save ozone-site --output="${{ env.image_tar }}"
+    - name: Save docker image tar to cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.image_tar }}
+        key: image-${{ hashFiles('Dockerfile', 'compose.yml', 'pnpm-lock.yaml') }}
+  build-website:
+    needs:
+    - build-image
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v4
+    - name: Restore docker image tar from cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.image_tar }}
+        key: image-${{ hashFiles('Dockerfile', 'compose.yml', 'pnpm-lock.yaml') }}
+    - name: Load docker image
+      run: |
+        docker load --input="${{ env.image_tar }}"
+    - name: Build website
+      run: |
+        docker compose run site pnpm build
+    - name: Save website build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: build
+        path: build
+        if-no-files-found: error
+        retention-days: 1
+  run-website:
+    needs:
+    - build-website
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Docker files
+      uses: actions/checkout@v4
+    - name: Download website build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: build
+        path: build
+    - name: Restore docker image tar from cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.image_tar }}
+        key: image-${{ hashFiles('Dockerfile', 'compose.yml', 'pnpm-lock.yaml') }}
+    - name: Load docker image
+      run: |
+        docker load --input="${{ env.image_tar }}"
+    - name: Curl website homepage
+      timeout-minutes: 5
+      working-directory: ${{ env.script_dir }}
+      run: |
+        ./curl.sh

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Builds the website and runs tests using Docker.
+# The Docker image contains only pnpm prod dependencies, so it is cached.
+# The website build is stored as an artifact.
+
 name: docusaurus
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,50 +13,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build Ozone website v2 and commit it to a staging branch.
-# This will be picked up by configurations in .asf.yml to publish it to a staging domain.
-name: "auto-publish-website-v2"
+name: publish
 
 on:
-  push:
-    branches:
-      # TODO update this to master when the new website is ready to be published.
-      - HDDS-9225-website-v2
+  workflow_call:
+
+concurrency:
+  group: publish-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  publish-website:
     runs-on: ubuntu-latest
     steps:
-      # Check out the website source in the current working directory.
-      - name: "Checkout source branch ${{ github.ref_name }}"
-        uses: actions/checkout@v4
-        with:
-          path: 'src'
-      - name: "Build website"
-        working-directory: 'src'
-        # Website source is mounted as volume, so the build output ends up in ./src/build outside of the container.
-        run: |
-          docker compose run site pnpm run build
-      - name: "Checkout publish branch"
-        uses: actions/checkout@v4
-        with:
-          path: 'publish'
-          # TODO update this to asf-site when the website is ready to be published.
-          ref: 'asf-site-v2'
-      - name: "Commit changes"
-        working-directory: 'publish'
-        run: |
-          # Delete previous build from the branch, but preserve files with necessary metadata.
-          mv README.md .asf.yaml .git /tmp
-          rm -rf $(ls -A)
-          mv /tmp/README.md /tmp/.asf.yaml /tmp/.git .
+    - name: Download website build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: build
+        path: build
+    - name: Checkout publish branch
+      uses: actions/checkout@v4
+      with:
+        path: publish
+        # Update this to asf-site when the website is ready to be published.
+        ref: asf-site-v2
+    - name: Commit changes
+      working-directory: publish
+      run: |
+        # Delete previous build from the branch, but preserve files with necessary metadata.
+        mv README.md .asf.yaml .git /tmp
+        rm -rf $(ls -A)
+        mv /tmp/README.md /tmp/.asf.yaml /tmp/.git .
 
-          # Commit new build to the branch.
-          cp -R ../src/build/. .
-          git config --global user.name 'Github Actions'
-          git config --global user.email 'noreply@github.com'
-          git add .
-          git commit -a -m "[auto] Apply changes from $GITHUB_REF_NAME $GITHUB_SHA" || true
-          git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Commit new build to the branch.
+        cp -R ../build/. .
+        git config --global user.name 'Github Actions'
+        git config --global user.email 'noreply@github.com'
+        git add .
+        git commit -a -m "[auto] Apply changes from $GITHUB_REF_NAME $GITHUB_SHA" || true
+        git push
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,14 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Commits the website build to the asf-site-v2 branch, where ASF automation configured by the .asf.yaml file on that
+# branch will publish it to the specified domain.
+# The website build is read from an artifact and is not built in this workflow.
+
 name: publish
 
 on:
   workflow_call:
 
 concurrency:
-  group: publish-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: publish-${{ github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   publish-website:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ Docusaurus supports previewing the website locally. Below are various options to
 
 #### Option 1: Docker (Recommended)
 
-The project includes a `Dockerfile` and a `compose.yml` file to build and run the website in a containerized environment. This creates a docker image called `ozone-site-dev` with all the dependencies included, and uses it to run the [Docusaurus development server](https://docusaurus.io/docs/installation#running-the-development-server).
+The project includes a `Dockerfile` and a `compose.yml` file to build and run the website in a containerized environment. This creates a docker image called `ozone-site` with all the dependencies included, and uses it to run the [Docusaurus development server](https://docusaurus.io/docs/installation#running-the-development-server).
 
 1. Install [docker](https://docs.docker.com/engine/install/).
 

--- a/compose.yml
+++ b/compose.yml
@@ -18,7 +18,7 @@ version: "3"
 services:
   site:
     build: "."
-    image: "ozone-site-dev"
+    image: "ozone-site"
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
## Summary

Add a GitHub actions workflow to build the website from the docker image, then run and query the site with curl to check that it comes up.

This PR adds a ci.yml file as the main driver of the CI workflow, where each job is added as a separate workflow in its own file. When static analysis checks are introduced later, ci.yml will invoke them from static.yml before the build/run/publish checks.

Minor optimizations:
- The docker image only contains dependencies, and is cached.
- The website build is stored as an artifact and passed to the run and publish jobs

## Jira

HDDS-10352

## Testing

- An initial passing run on my [fork](https://github.com/errose28/ozone-site/actions/runs/7880065041)
- A [second passing run](https://github.com/errose28/ozone-site/actions/runs/7880109167) using the cached image to speed up the build step