### PR TITLE
HDDS-10400. Fix website publish workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,5 @@ jobs:
   publish:
     needs: docusaurus
     # Update this to master when the website is ready to be published.
-    if: ${{ github.event == 'push' && github.ref_name == 'HDDS-9225-website-v2' }}
+    if: ${{ github.event_name == 'push' && github.ref_name == 'HDDS-9225-website-v2' }}
     uses: ./.github/workflows/publish.yml

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can preview the current state of the new website at https://ozone-site-v2.st
 
 - The `master` branch is still tracking content for the currently active Ozone website. `master` and `HDDS-9225-website-v2` will remain separate until the new website is ready to be deployed.
 
-- The `asf-site` branch is still holding build artifacts being used to deploy content from the `master` branch. The new website is not being hosted anywhere, but can be previewed locally.
+- The `asf-site` branch is still holding build artifacts being used to deploy content from the `master` branch.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

[HDDS-10352](https://issues.apache.org/jira/browse/HDDS-10352) moved the publish workflow to the main ci.yml file. As part of the move, the check incorrectly checked github.event instead of github.event_name in the trigger to run. This resulted in the publish workflow always being skipped.

## Jira

HDDS-10400

## Testing

- I pushed the same commit directly to the `HDDS-9225-website-v2` branch in my fork and the [publish workflow ran](https://github.com/errose28/ozone-site/actions/runs/7982396754).
- Publish workflow should not run on this PR's CI.