### PR TITLE
HDDS-10441. Add website PR template to default branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## What changes were proposed in this pull request?
+
+Provide a one line summary of the changes in the PR **Title** field above.
+It should be in the form of `HDDS-1234. Short summary of the change`.
+
+Please describe your PR in detail:
+- What changes are proposed in the PR and why? It would be better if it is written from third person's perspective not just for the reviewer.
+- Provide as much context and rationale for the pull request as possible. It could be copy-pasted from the Jira's description if the Jira is well defined.
+
+## What is the link to the Apache Jira?
+
+1. Please create an issue in ASF Jira before opening a pull request.
+2. Start the title of the pull request with the corresponding Jira issue number (e.g. HDDS-XXXX. Fix a typo in YYY).
+3. Add the `website` and/or `documentation` labels to your Jira if applicable.
+4. Replace this section with the link to the Apache Jira.
+
+## How was this patch tested?
+
+Please explain how this patch was tested. In most cases this will just be checking the local preview of the website, but existing CI checks should also pass.
+


### PR DESCRIPTION
Cherry pick of #70 to the GitHub default branch, which is now master. The PR template should actually be used after this is merged.