### PR TITLE
HDDS-10351. Add GitHub Actions check for yaml formatting.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,4 +16,4 @@
 # Configuration for .github/workflows/label-pr.yml
 # This workflow and its configuration can be deleted once the website's feature branch is merged.
 website-v2:
-  - base-branch: HDDS-9225-website-v2
+- base-branch: HDDS-9225-website-v2

--- a/.github/scripts/yamllint.sh
+++ b/.github/scripts/yamllint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+root="$(git rev-parse --show-toplevel)"
+yamllint --format=colored "$root"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -15,7 +15,7 @@
 
 # This workflow reads its configuration from the .github/labeler.yml file.
 # This workflow and its configuration can be deleted once the website's feature branch is merged.
-name: "Pull Request Labeler"
+name: Pull Request Labeler
 on:
 - pull_request_target
 

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -15,7 +15,7 @@
 
 # This workflow reads its configuration from the .github/labeler.yml file.
 # This workflow and its configuration can be deleted once the website's feature branch is merged.
-name: Pull Request Labeler
+name: pull request labeler
 on:
 - pull_request_target
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,20 +18,19 @@ name: pull request
 on:
   pull_request:
     types:
-      - reopened
-      - opened
-      - edited
-      - synchronize
+    - reopened
+    - opened
+    - edited
+    - synchronize
 
 jobs:
   title:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout project
-        uses: actions/checkout@v4
-      - name: Check pull request title
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-        run:
-          .github/scripts/pr_title_check.sh "${TITLE}"
-
+    - name: Checkout project
+      uses: actions/checkout@v4
+    - name: Check pull request title
+      env:
+        TITLE: ${{ github.event.pull_request.title }}
+      run:
+        .github/scripts/pr_title_check.sh "${TITLE}"

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Static analysis of website files. These jobs only require pnpm's dev dependencies and does not build or run the website.
+# Static analysis of website files.
+# These jobs only require pnpm's dev dependencies and do not building or running the website.
 
 name: static
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -109,3 +109,12 @@ jobs:
       working-directory: ${{ env.script_dir }}
       run: |
         ./sidebar.sh
+  lint-yaml:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v4
+    - name: Run yamllint
+      working-directory: ${{ env.script_dir }}
+      run: |
+        ./yamllint.sh

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# This file extends the defaults present in https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
+# This file extends the defaults present in
+# https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
 
 # Only - (dash) character is allowed for bullet lists.
 heading-increment:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Ref: https://yamllint.readthedocs.io/en/stable/rules.html
+
+ignore:
+- pnpm-lock.yaml
+- node_modules
+
+rules:
+  anchors: enable
+  braces:
+    forbid: false
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 1
+  brackets:
+    forbid: false
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 1
+  # Use default values to control spaces around colons.
+  colons: enable
+  # Use default values to control spaces around commas.
+  commas: enable
+  # Rules for spacing around comments.
+  comments:
+    min-spaces-from-content: 1
+  # Comments should be indented at the same level as the content they are commenting.
+  comments-indentation: enable
+  # No requirements on document start or end markers.
+  document-end: disable
+  document-start: disable
+  empty-lines:
+    max: 1
+  # Empty values are allowed, disable enforcement of this rule.
+  empty-values: disable
+  float-values:
+    require-numeral-before-decimal: true
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: 2
+    indent-sequences: false
+    check-multi-line-strings: false
+  # Enable checking that there are no duplicate keys.
+  key-duplicates: enable
+  key-ordering: disable
+  # Max line length is the same as the main Ozone project.
+  # Non-breakable words like URLs are excluded.
+  line-length:
+    max: 120
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  # 0o prefix without quotes must be used to indicate octal values.
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: false
+  quoted-strings:
+    quote-type: double
+    required: only-when-needed
+  # Enable check for no trailing spaces.
+  trailing-spaces: enable
+  # Only use true and false to represent boolean values.
+  truthy:
+    # Prevent this from flagging Github actions key "on".
+    check-keys: false

--- a/compose.yml
+++ b/compose.yml
@@ -17,15 +17,16 @@ version: "3"
 
 services:
   site:
-    build: "."
-    image: "ozone-site"
+    build: .
+    image: ozone-site
     ports:
-      - 3000:3000
+    - 3000:3000
     volumes:
-      - ".:/ozone-site"
-      # The below option is used to prevent overwriting the node_modules directory in the docker image
-      # with the node_modules present in the mounted volume.
-      # This will create an empty node_modules directory in the working directory of the host if it is not already present.
-      - /ozone-site/node_modules/
-    working_dir: "/ozone-site"
+    - .:/ozone-site
+    # The below option is used to prevent overwriting the node_modules directory in the docker image
+    # with the node_modules present in the mounted volume.
+    # This will create an empty node_modules directory in the working directory of the host if it is not already
+    # present.
+    - /ozone-site/node_modules/
+    working_dir: /ozone-site
     command: pnpm start --host '0.0.0.0'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use [yamllint](https://github.com/adrienverge/yamllint) to to check yaml configuration files. This isn't a very important check IMO since most website changes will not be editing yaml files, and the `_category_.yml` files are pretty simple. However [yamllint is already in the GitHub actions Ubuntu runner](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) so it's low effort to add this check.

I set the yaml linting rules based on what I usually follow but I don't have strong opinions on them as long as they are consistent.

## What is the link to the Apache Jira?

HDDS-10351

## How was this patch tested?

- Failing CI run with yamllint added but existing errors not enforced: https://github.com/errose28/ozone-site/actions/runs/8427283082/job/23077474962

- CI on this PR should pass with the fixed yaml files.
