### PR TITLE
HDDS-10698. Bump skywalking-eyes to v0.6.0

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Checkout project
       uses: actions/checkout@v4
     - name: Check Apache license headers
-      uses: apache/skywalking-eyes@v0.5.0
+      uses: apache/skywalking-eyes@v0.6.0
   file-names:
     runs-on: ubuntu-latest
     steps:

--- a/compose.yml
+++ b/compose.yml
@@ -1,18 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 version: "3"
 
 services:

--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "3"
 
 services:


### PR DESCRIPTION
## What changes were proposed in this pull request?

skywalking-eyes has released [version 0.6.0](https://github.com/apache/skywalking-eyes/releases/tag/v0.6.0). This fixes the warning about deprecated node version from github actions, so we should upgrade to the new version.

## What is the link to the Apache Jira?

HDDS-10698

## How was this patch tested?

- [Failing run](https://github.com/errose28/ozone-site/actions/runs/8697967689/job/23854181129) using the new version where a license header was intentionally removed.
- CI on this PR should pass without a warning about using a deprecated node version.

