### PR TITLE
HDDS-10989. Update release guide to bump release year

### DIFF
--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -181,6 +181,11 @@ find . -name pom.xml -type f -print0 | xargs -0 sed -i '' "s/$VERSION-SNAPSHOT/$
 </TabItem>
 </Tabs>
 
+```xml title="Update release year tag in root POM. e.g."
+    <!-- Set the Release year during release -->
+    <release-year>2024</release-year>
+```
+
 ```bash title="Commit the Version Changes "
 git commit -am "Update Ozone version to $VERSION"
 ```


### PR DESCRIPTION
## What changes were proposed in this pull request?

Include a paragraph in the release guide to bump release year. Albeit `release-year` does not seem to be used anywhere in Ozone like it does in [Hadoop](https://github.com/apache/hadoop/blob/06db6289cb40d34cd382080dedc86ff8ae437f9c/hadoop-hdfs-project/hadoop-hdfs/pom.xml#L280).

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-10989

## How was this patch tested?

- n/a