### PR TITLE
HDDS-11344. Change dev server port to avoid conflict with Grafana.

### DIFF
--- a/.github/scripts/curl.sh
+++ b/.github/scripts/curl.sh
@@ -19,7 +19,7 @@
 
 echo 'Running website and checking homepage...'
 docker compose run --detach --service-ports site pnpm serve
-while [ "$(curl -so /dev/null -w '%{http_code}' http://localhost:3000)" != 200 ]; do
+while [ "$(curl -so /dev/null -w '%{http_code}' http://localhost:3001)" != 200 ]; do
   sleep 1;
 done
 echo 'Website homepage is responsive.'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This document summarizes the contribution process.
 2. Use your favorite editor to write markdown content under the [docs/](docs/) and [src/pages/](src/pages/) directories.
     - A good option is [Visual Studio Code](https://code.visualstudio.com/) with [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) and [cspell](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) plugins, which will automatically detect the website's configuration files and give feedback as you type.
 
-3. Preview your changes locally by running `docker compose up` and opening `localhost:3000` in your browser.
+3. Preview your changes locally by running `docker compose up` and opening `localhost:3001` in your browser.
     - Make sure [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) are installed on your system.
     - If you need to update the dependencies in your Docker image at any time, run `docker compose up --build` to create an updated image.
 
@@ -280,7 +280,7 @@ Currently all `@docusaurus/*` packages are pinned to an exact version for websit
 
 ### Previewing Your Modifications Locally
 
-Docusaurus supports previewing the website locally. Below are various options to launch a preview of the site at `localhost:3000` on your machine.
+Docusaurus supports previewing the website locally. Below are various options to launch a preview of the site at `localhost:3001` on your machine.
 
 **NOTE**: If using the [Docusaurus development server](https://docusaurus.io/docs/installation#running-the-development-server), changes to `docusaurus.config.js` may not be automatically reloaded and require the server to be restarted.
 
@@ -297,7 +297,7 @@ The project includes a `Dockerfile` and a `compose.yml` file to build and run th
     - **Note**: This will continue to use the last locally built version of the `ozone-site-dev` image, which saves time on future runs.
       - Run `docker compose up --build` to rebuild the image and incorporate any package dependency updates that may have been committed since the last build.
 
-4. Preview the website at `localhost:3000` in your browser.
+4. Preview the website at `localhost:3001` in your browser.
 
     - Any changes made in the repository will be reflected in the preview.
 
@@ -315,7 +315,7 @@ Build and run the website locally with the `pnpm` package manager.
 
   1. Run `pnpm start` from the repository root to start the development server.
 
-  2. Preview the website at `localhost:3000` in your browser.
+  2. Preview the website at `localhost:3001` in your browser.
 
   3. Press `Ctrl+C` to stop the preview.
 
@@ -325,7 +325,7 @@ Build and run the website locally with the `pnpm` package manager.
 
   2. Run `pnpm serve` to preview the built website locally.
 
-  3. Preview the website at `localhost:3000` in your browser.
+  3. Preview the website at `localhost:3001` in your browser.
 
   4. Press `Ctrl+C` to stop the preview.
 

--- a/compose.yml
+++ b/compose.yml
@@ -20,7 +20,7 @@ services:
     build: .
     image: ozone-site
     ports:
-    - 3000:3000
+    - 3001:3001
     volumes:
     - .:/ozone-site
     # The below option is used to prevent overwriting the node_modules directory in the docker image

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,7 +33,7 @@ const config = {
 
   // Set the production URL of the website. Must be updated when the final site is deployed.
   // This must match the URL the website is hosted at for social media previews to work.
-  // If you are testing the social media image (themeConfig.image) locally, set this to http://localhost:3000.
+  // If you are testing the social media image (themeConfig.image) locally, set this to http://localhost:3001.
   url: 'https://ozone-site-v2.staged.apache.org',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --port 3001",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "docusaurus serve --port 3001",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?

Port 3000 is the default for the Docusaurus dev server which comes from Node/React/Webpack, but it is also the default for Grafana. Ozone devs may have a Grafana instance running in docker already for testing which might conflict with the local preview, especially if they are updating Grafana related documentation. This PR changes the docusaurus default port to 3001 to avoid conflict.

## What is the link to the Apache Jira?

HDDS-11344

## How was this patch tested?

- `pnpm start` runs on port 3001 by default
- `docker compose up` runs on port 3001 by default
- `pnpm build && pnpm serve` runs on port 3001 by default
- [CI curl test](https://github.com/errose28/ozone-site/actions/runs/10475183813/job/29011367415) uses the new port and passes.
