### PR TITLE
HDDS-11673. List supported releases in Downloads page

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -35,7 +35,7 @@ gpg --import KEYS
 gpg --verify ozone-${OZONE_VERSION}-src.tar.gz.asc ozone-${OZONE_VERSION}-src.tar.gz
 ```
 
-## SHA-512 checksum
+### SHA-512 checksum
 
 ```
 sha512sum -c ozone-${OZONE_VERSION}-src.tar.gz

--- a/content/downloads.md
+++ b/content/downloads.md
@@ -17,6 +17,12 @@ type: custompage
   limitations under the License. See accompanying LICENSE file.
 -->
 
+### Archives
+
+Releases starting with 1.1.0, when Apache Ozone became a top-level project, are available in the [Ozone archives](https://archive.apache.org/dist/ozone/).
+
+Releases before that can be found in [Apache Hadoop archives](https://archive.apache.org/dist/hadoop/ozone/).
+
 ## Download
 
 1.  Download the release `ozone-${OZONE_VERSION}-src.tar.gz` from a [mirror
@@ -40,12 +46,6 @@ gpg --verify ozone-${OZONE_VERSION}-src.tar.gz.asc ozone-${OZONE_VERSION}-src.ta
 ```
 sha512sum -c ozone-${OZONE_VERSION}-src.tar.gz
 ```
-
-## Archives
-
-Releases starting with 1.1.0, when Apache Ozone became a top-level project, are available in the [Ozone archives](https://archive.apache.org/dist/ozone/).
-
-Releases before that can be found in [Apache Hadoop archives](https://archive.apache.org/dist/hadoop/ozone/).
 
 ## License
 

--- a/content/downloads.md
+++ b/content/downloads.md
@@ -17,26 +17,35 @@ type: custompage
   limitations under the License. See accompanying LICENSE file.
 -->
 
-## To verify Apache Ozone releases using GPG:
+## Download
 
-1.  Download the release ozone-X.Y.Z-src.tar.gz from a [mirror
+1.  Download the release `ozone-${OZONE_VERSION}-src.tar.gz` from a [mirror
     site](https://www.apache.org/dyn/closer.cgi/ozone).
-2.  Download the signature file ozone-X.Y.Z-src.tar.gz.asc from
+2.  Download signature or checksum from
     [Apache](https://downloads.apache.org/ozone/).
-3.  Download the Ozone [KEYS](https://downloads.apache.org/ozone/KEYS)
-    file.
-4.  `gpg --import KEYS`
-5.  `gpg --verify ozone-X.Y.Z-src.tar.gz.asc ozone-X.Y.Z-src.tar.gz`
 
-## To perform a quick check using SHA-512:
+## Verify
 
-1.  Download the release ozone-X.Y.Z-src.tar.gz from a [mirror
-    site](https://www.apache.org/dyn/closer.cgi/hadoop/ozone).
-2.  Download the checksum ozone-X.Y.Z-src.tar.gz.sha512 from
-    [Apache](https://downloads.apache.org/ozone/).
-3.  `sha512sum -c ozone-X.Y.Z-src.tar.gz`
+### GnuPG signature
 
-Note: Before 1.1.0 release Ozone was part of the Apache Hadoop project. Older release artifacts can be found [there](https://archive.apache.org/dist/hadoop/ozone/).
+Download Ozone developers' public [KEYS](https://downloads.apache.org/ozone/KEYS).
+
+```
+gpg --import KEYS
+gpg --verify ozone-${OZONE_VERSION}-src.tar.gz.asc ozone-${OZONE_VERSION}-src.tar.gz
+```
+
+## SHA-512 checksum
+
+```
+sha512sum -c ozone-${OZONE_VERSION}-src.tar.gz
+```
+
+## Archives
+
+Releases starting with 1.1.0, when Apache Ozone became a top-level project, are available in the [Ozone archives](https://archive.apache.org/dist/ozone/).
+
+Releases before that can be found in [Apache Hadoop archives](https://archive.apache.org/dist/hadoop/ozone/).
 
 ## License
 

--- a/content/release/1.0.0.md
+++ b/content/release/1.0.0.md
@@ -1,7 +1,6 @@
 ---
 title: Release 1.0.0 available
 date: 2020-09-02
-linked: true
 hadoop: true
 ---
 <!---

--- a/content/release/1.1.0.md
+++ b/content/release/1.1.0.md
@@ -1,7 +1,6 @@
 ---
 title: Release 1.1.0 available
 date: 2021-04-17
-linked: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/release/1.2.1.md
+++ b/content/release/1.2.1.md
@@ -1,7 +1,6 @@
 ---
 title: Release 1.2.1 available
 date: 2021-12-22
-linked: true
 aliases:
     - /release/1.2.0
 ---

--- a/content/release/1.3.0.md
+++ b/content/release/1.3.0.md
@@ -1,7 +1,6 @@
 ---
 title: Release 1.3.0 available
 date: 2022-12-18
-linked: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -16,10 +16,12 @@
 
   <h1>Download</h1>
 
-  <p>Apache Ozone is released as source code tarballs with corresponding binary
-  tarballs for convenience. The downloads are distributed via mirror sites
-  and should be checked for tampering using GPG or SHA-512.</p>
+  <p>Apache Ozone is released as source code tarball.  Binary tarballs are also
+  provided for convenience.  Both kinds of tarballs are distributed via mirror
+  sites.  Theyt should be verified after download against checksums and
+  signatures, available directly from Apache.</p>
 
+  <h2>Supported Releases</h2>
 <p>
   <table class="table table-striped">
     <thead>
@@ -35,35 +37,19 @@
      <tr>
        <td>{{.File.BaseFileName }}</td>
        <td>{{dateFormat "2006 Jan 2 " .Date}}</td>
-       {{ if eq .Params.hadoop true }}
-         <td>
-           <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
-           (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>
-           <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
-          </td>
-          <td>
-            <a href="https://www.apache.org/dyn/closer.cgi/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
-            (<a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.mds">checksum</a>
-            <a href="https://downloads.apache.org/hadoop/ozone/ozone-{{.File.BaseFileName }}/hadoop-ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
-           </td>
-           <td>
-             <a href="release/{{.File.BaseFileName }}/">Announcement</a>
-           </td>
-       {{else}}
-         <td>
-           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
-           (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
-           <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
-         </td>
-         <td>
-           <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
-           (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
-           <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
-         </td>
-         <td>
-           <a href="release/{{.File.BaseFileName }}/">Announcement</a>
-         </td>
-       {{end}}
+       <td>
+         <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
+         (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
+         <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
+       </td>
+       <td>
+         <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
+         (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
+         <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
+       </td>
+       <td>
+         <a href="release/{{.File.BaseFileName }}/">Announcement</a>
+       </td>
      </tr>
   {{end}}
   </table>

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -33,7 +33,7 @@
       <th>Release notes</th>
     </tr>
   </thead>
-   {{range first 5 (where (where .Site.Pages "Section" "release") ".Params.linked" true) }}
+   {{range (where (where .Site.Pages "Section" "release") ".Params.linked" true) }}
      <tr>
        <td>{{.File.BaseFileName }}</td>
        <td>{{dateFormat "2006 Jan 2 " .Date}}</td>

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -39,12 +39,12 @@
        <td>{{dateFormat "2006 Jan 2 " .Date}}</td>
        <td>
          <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>
+         (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.sha512">checksum</a>,
          <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}-src.tar.gz.asc">signature</a>)
        </td>
        <td>
          <a href="https://www.apache.org/dyn/closer.cgi/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz">binary</a>
-         (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>
+         (<a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.sha512">checksum</a>,
          <a href="https://downloads.apache.org/ozone/{{.File.BaseFileName }}/ozone-{{.File.BaseFileName }}.tar.gz.asc">signature</a>)
        </td>
        <td>

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -22,6 +22,8 @@
   signatures, available directly from Apache.</p>
 
   <h2>Supported Releases</h2>
+Releases in the table are supported by the Apache Ozone community for security fixes.  Other versions are not supported, but are available from the archives.
+
 <p>
   <table class="table table-striped">
     <thead>

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -18,7 +18,7 @@
 
   <p>Apache Ozone is released as source code tarball.  Binary tarballs are also
   provided for convenience.  Both kinds of tarballs are distributed via mirror
-  sites.  Theyt should be verified after download against checksums and
+  sites.  They should be verified after download against checksums and
   signatures, available directly from Apache.</p>
 
   <h2>Supported Releases</h2>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update Downloads page to list only supported releases (currently 1.4.0).  Older releases should not be promoted, but they are available from archives.

Also update other parts of the Downloads page, hopefully an improvement.

https://issues.apache.org/jira/browse/HDDS-11673

## How was this patch tested?

```
hugo serve &
open http://localhost:1313/downloads/
```

:eyes:

Screenshot for convenience:

![Screenshot from 2024-11-12 07-50-02](https://github.com/user-attachments/assets/e5e84695-5069-4af7-af5d-2ae032cd2021)