### PR TITLE
HDDS-11709. Simplify post-vote svn instructions

### DIFF
--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -382,23 +382,12 @@ Once voting is finished, send an email summarizing the results (binding +1s, non
 
 ### Publish the Artifacts
 
-You should commit the artifacts to the SVN repository. If you are not a PMC member you can commit it to the dev zone first and ask a PMC for the final move.
-
-Checkout the svn folder and commit the artifacts to a new directory.
+If you are a PMC member, move artifacts in Subversion to the final location, otherwise ask the PMC to do the same:
 
 ```bash
-svn checkout https://dist.apache.org/repos/dist/dev/ozone
-cd ozone
-svn mkdir "$VERSION"
-cp "$RELEASE_DIR"/* "$VERSION"/
-svn add "$VERSION"/*
-svn commit -m "Added ozone-$VERSION directory"
-```
-
-PMC members can move it to the final location:
-
-```bash
-svn mv -m "Move ozone-$VERSION to release" https://dist.apache.org/repos/dist/dev/ozone/"$VERSION" https://dist.apache.org/repos/dist/release/ozone/"$VERSION"
+svn mv -m "Release ozone-$VERSION-rc$RC as ozone-$VERSION" \
+  https://dist.apache.org/repos/dist/dev/ozone/"$VERSION-rc$RC" \
+  https://dist.apache.org/repos/dist/release/ozone/"$VERSION"
 ```
 
 To publish the artifacts to [Maven Central](https://central.sonatype.com), login to https://repository.apache.org/#stagingRepositories, select your **staging** repository and **release** it.


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the vote, we should publish artifacts by moving them within Subversion.

The goal of the voting process is to validate the artifacts being released.  The release manager should not add anything to Subversion after that.  We should move the exact same artifacts checked by the community.

This also simplifies life for the release manager in the non-PMC member case.

https://issues.apache.org/jira/browse/HDDS-11709

## How was this patch tested?

```
docker compose up
open "http://localhost:3001/docs/developer-guide/project/release-guide"
```