### PR TITLE
HDDS-11710. Share gitignore between dev branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ yarn-error.log*
 
 # IDE - JetBrains IntelliJ
 .idea/
+
+# Website v1 generated files
+public
+hugo
+.hugo_build.lock


### PR DESCRIPTION
## What changes were proposed in this pull request?

Untracked items appear when switching between development branches of the website (`master` and `HDDS-9225-website-v2`).

```
$ git status
On branch HDDS-9225-website-v2
Your branch is up to date with 'origin/HDDS-9225-website-v2'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.hugo_build.lock
```

```
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.docusaurus/
```

We should share the same gitignore file between these two.

If this is approved, I'll add the same file to `master`.

https://issues.apache.org/jira/browse/HDDS-11710

## How was this patch tested?

```
$ git status
On branch HDDS-11710
nothing to commit, working tree clean
```

With branch created from `master`:

```
$ git status
On branch HDDS-11710-v1
nothing to commit, working tree clean
```
