### PR TITLE
HDDS-11871. Update Publish Ozone docs workflow for HDDS-11365

### DIFF
--- a/.github/workflows/ozone-docs.yml
+++ b/.github/workflows/ozone-docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build Ozone docs
         working-directory: ozone
         run: |
-          mvn --no-transfer-progress -pl :hdds-docs clean package
+          hadoop-ozone/dev-support/checks/docs.sh
           mv hadoop-hdds/docs/target/classes/docs ../edge
       - name: Checkout Ozone Site generated version
         uses: actions/checkout@v4

--- a/.github/workflows/ozone-docs.yml
+++ b/.github/workflows/ozone-docs.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           repository: apache/ozone
           path: ozone
+          fetch-depth: 0
       - name: Build Ozone docs
         working-directory: ozone
         run: |


### PR DESCRIPTION
## What changes were proposed in this pull request?

Problem 1: `edge` docs are not updated in the website.

- HDDS-7678 added workflow for publishing content from `hdds-docs` to the website.
- INFRA-25530 changed default branch from `asf-site` to `master`, effectively disabling the workflow (scheduled workflows need to be present in the default branch).
- Cherry-picked the workflow to `master` as it was added in HDDS-7678.
- HDDS-11365 introduced `ozone-dev-support` module, which is not available when building only the docs.

So workflow run fails with:

```
Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.7.0:process (default) on project hdds-docs: Execution default of goal org.apache.maven.plugins:maven-remote-resources-plugin:1.7.0:process failed: Plugin org.apache.maven.plugins:maven-remote-resources-plugin:1.7.0 or one of its dependencies could not be resolved: Could not find artifact org.apache.ozone:ozone-dev-support:jar:2.0.0-SNAPSHOT in apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots)
```

0c4abe67826e9692f94a7d99e0dc36ab8abea638 fixes this by executing Hugo directly, bypassing Maven.
This is achieved by running the same command as `basic (docs)` check in Ozone CI.

Problem 2: `edge` docs are updated by the workflow even if no docs were changed.

- Doc footer includes `Last Modified` time and commit information.
- `actions/checkout` clones the repo without history by default.
- Hugo only has information about the most recent commit, marking every page as modified by that one.
- `Last Modified` information is wrong, and workflow finds "changes" in doc every day.

36f548860cc832c25524fba5eae6659586c72383 fixes this by cloning `apache/ozone` with history.

Since both fixes are one-liners, I bundled them in the same PR.

https://issues.apache.org/jira/browse/HDDS-11871

## How was this patch tested?

Run 1: https://github.com/adoroszlai/ozone-site/actions/runs/12197628118
Doc update: https://github.com/adoroszlai/ozone-site/commit/88c05d37c2dc72e4baeef66a53b04ea6c9fb1edc
- pick up recent doc additions, e.g. `tools/debug`
- update footer with proper last modified information

Run 2: https://github.com/adoroszlai/ozone-site/actions/runs/12197847484
Doc update: none
```
Your branch is up to date with 'origin/asf-site'.
nothing to commit, working tree clean
Everything up-to-date
```