### PR TITLE
HDDS-11925. Fix deploy step in Release Manager guide

### DIFF
--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -22,6 +22,8 @@ In addition to the usual development tools required to work on Ozone, the follow
 - [GnuPG](https://www.gnupg.org/) to manage your GPG keys.
 - [Protolock](https://github.com/nilslice/protolock) to manage protocol buffer compatibility.
 
+Make sure you are using GNU-tar instead of BSD-tar.
+
 ### Publish Your GPG Key
 
 Create a GPG key to sign the artifacts if you do not already have one. For help creating your key refer to the [ASF new committer guide](https://www.apache.org/dev/new-committers-guide.html#set-up-security-and-pgp-keys). The release manager's GPG key is supposed to be published together with the release. Please append it to the end of the [KEYS file](https://dist.apache.org/repos/dist/release/ozone/KEYS) stored in Subversion, if it is not already present.
@@ -55,6 +57,22 @@ svn commit -m "ozone: adding key of <your_name> to the KEYS"
 ```bash title="Move Key (PMC)"
 svn cp -m "ozone: adding key of <name> to the KEYS" https://dist.apache.org/repos/dist/dev/ozone/KEYS https://dist.apache.org/repos/dist/release/ozone/KEYS
 ```
+
+### Configure Maven Credentials
+
+Add your Apache credentials to the local Maven settings `~/.m2/settings.xml`.
+
+  ```xml title="settings.xml"
+  <settings>
+    <servers>
+      <server>
+        <id>apache.staging.https</id>
+        <username>your_apache_id</username>
+        <password>your_apache_password</password>
+      </server>
+    </servers>
+  </settings>
+  ```
 
 ## Pre-Vote
 
@@ -228,7 +246,7 @@ If the command fails on MacOS, you may need to do the following additional steps
 
 :::
 
-### Build the Project
+### Perform Sanity Checks
 
 - Run rat check and ensure there are no failures.
 
@@ -243,7 +261,9 @@ If the command fails on MacOS, you may need to do the following additional steps
   git clean -dfx
   ```
 
-- Build the project. Make sure you are using GNU-tar instead of BSD-tar.
+### Build the Project
+
+Build the project to fetch dependencies.
 
   ```bash
   mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname="$CODESIGNINGKEY"
@@ -251,27 +271,13 @@ If the command fails on MacOS, you may need to do the following additional steps
 
 ### Create and Upload Maven Artifacts
 
-- Double check that your Apache credentials are added to your local `~/.m2/settings.xml`.
-
-  ```xml title="settings.xml"
-  <settings>
-    <servers>
-      <server>
-        <id>apache.staging.https</id>
-        <username>your_apache_id</username>
-        <password>your_apache_password</password>
-      </server>
-    </servers>
-  </settings>
-  ```
-
-- Return to your Ozone repository being used for the release, and run the following command to perform the final build and upload the release artifacts:
+- Perform the final build and upload the release artifacts.
 
   ```bash
   mvn deploy -DdeployAtEnd=true -Dmaven.javadoc.skip=true -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname="$CODESIGNINGKEY"
   ```
 
-Go to https://repository.apache.org/#stagingRepositories and **close** the newly created `orgapacheozone` repository.
+- Go to https://repository.apache.org/#stagingRepositories and **close** the newly created `orgapacheozone` repository.
 
 ### Calculate the Checksum and Sign the Artifacts
 

--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -352,7 +352,7 @@ Double check that your Apache credentials are added to your local `~/.m2/setting
 Return to your Ozone repository being used for the release, and run the following command to upload the release artifacts:
 
 ```bash
-mvn deploy -Psign -pl '!:ozone-dist' -DskipTests -Dbuildhelper.skipAttach
+mvn deploy:deploy
 ```
 
 Go to https://repository.apache.org/#stagingRepositories and **close** the newly created `orgapacheozone` repository.


### PR DESCRIPTION
## What changes were proposed in this pull request?

`mvn deploy` rebuilds the project, as it executes all [phases of the default lifecycle](https://maven.apache.org/ref/3.9.9/maven-core/lifecycles.html#default-lifecycle) up to `deploy`.  Not only is it unnecessary, it causes jars to be [different between Maven repo and binary tarball](https://github.com/apache/ozone/discussions/7560).

`mvn deploy:deploy` just executes Maven Deploy Plugin's [`deploy` task](https://maven.apache.org/plugins/maven-deploy-plugin/usage.html#the-deploy-deploy-mojo), which is to upload artifacts to the remote repository.

Flags `-Psign -DskipTests -Dbuildhelper.skipAttach` can be removed, since they are specific to other plugins, which would (before this change) be executed in various lifecycle phases.

Skipping `:ozone-dist` seems to be unnecessary, too.  I don't see why we should not include it in the Maven repo.

**Update**: the proposed solution described above does not work, please see [this comment](https://github.com/apache/ozone-site/pull/109#issuecomment-2572923357) for current one.

https://issues.apache.org/jira/browse/HDDS-11925

## How was this patch tested?

Will be tested during next release.  (Tested similar change in Ratis, see https://github.com/apache/ratis/pull/1188.)