### PR TITLE
HDDS-11929. [Website v2] [Docs] [Administrator Guide] Tracking Metrics With Prometheus.

### DIFF
--- a/docs/05-administrator-guide/03-operations/09-observability/04-prometheus.md
+++ b/docs/05-administrator-guide/03-operations/09-observability/04-prometheus.md
@@ -1,7 +1,48 @@
 ---
 sidebar_label: Prometheus
 ---
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 
 # Tracking Metrics With Prometheus
 
-**TODO:** File a subtask under [HDDS-9859](https://issues.apache.org/jira/browse/HDDS-9859) and complete this page or section.
+Ozone has native support for Prometheus integration. All internal metrics (collected by Hadoop metrics framework) are published under the `/prom` HTTP endpoint. (For example under http://localhost:9876/prom for SCM).
+
+The Prometheus endpoint is turned on by default but can be turned off by the `hdds.prometheus.endpoint.enabled` configuration variable.
+
+In a secure environment the page is guarded with SPNEGO authentication which is not supported by Prometheus. To enable monitoring in a secure environment, a specific authentication token can be configured
+
+Example `ozone-site.xml`:
+
+```XML
+<property>
+   <name>hdds.prometheus.endpoint.token</name>
+   <value>putyourtokenhere</value>
+</property>
+```
+
+Example prometheus configuration:
+
+```YAML
+scrape_configs:
+  - job_name: ozone
+    bearer_token: <putyourtokenhere>
+    metrics_path: /prom
+    static_configs:
+     - targets:
+         - "127.0.0.1:9876"
+```


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11929. [Website v2] [Docs] [Administrator Guide] Tracking Metrics With Prometheus.

Migrate the Prometheus section of this doc https://ozone.apache.org/docs/edge/feature/observability.html to https://ozone-site-v2.staged.apache.org/docs/administrator-guide/operations/observability/prometheus

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-11929

## How was this patch tested?

Previewed locally.

<img width="1463" alt="Screenshot 2024-12-13 at 11 45 18 AM" src="https://github.com/user-attachments/assets/49861a53-ff25-4ce1-9b22-83411457e3c4" />

