### PR TITLE
HDDS-11968. Only check sibling headings for duplicate titles in markdown lint.

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -143,5 +143,6 @@ link-image-style:
 table-pipe-style:
   style: leading_and_trailing
 
+# Disallow duplicate headings at the same level under the same parent heading.
 no-duplicate-heading:
   siblings_only: true

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -142,3 +142,6 @@ link-image-style:
 # Use pipes on both ends of every line in a table.
 table-pipe-style:
   style: leading_and_trailing
+
+no-duplicate-heading:
+  siblings_only: true


### PR DESCRIPTION
## What changes were proposed in this pull request?

Markdownlint has a [check](https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md024.md) for duplicate headings, but by default it is global. We only want to enforce this for sibling headings, for example the following it ok:

```markdown
# Title
## Case 1
### Usage
## Case 2
### Usage
```

## What is the link to the Apache Jira?

HDDS-11968

## How was this patch tested?

Markdownlint check passed in [this run](https://github.com/errose28/ozone-site/actions/runs/12420912372/job/34679457299), which had duplicate non-sibling headings added [here](https://github.com/errose28/ozone-site/commit/ac1b313303af89f36452d3249c7290ba151d4115)
