### PR TITLE
HDDS-11970. Ignore markdown code blocks in cspell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ Docusaurus provides many options for laying out documentation pages and their me
 
 #### Spelling
 
-The file names and content of all markdown pages are checked for spelling mistakes using [cspell](https://cspell.org/) as part of GitHub actions. Spelling can also be checked locally by running the script [.github/scripts/spelling.sh](.github/scripts/spelling.sh). This requires you to have pnpm's dev dependencies installed on your machine for cspell to work (run `pnpm install --dev`).
+As part of the GitHub Actions CI, all markdown pages will be checked for spelling mistakes using [cspell](https://cspell.org/). Markdown code blocks are excluded from spelling checks. Spelling can also be checked locally by running the script [.github/scripts/spelling.sh](.github/scripts/spelling.sh). This requires you to have pnpm's dev dependencies installed on your machine for cspell to work (run `pnpm install --dev`).
 
 **If spell check fails for words that are correct but not recognized:**
 

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -33,6 +33,25 @@ import:
 - "@cspell/dict-shell/cspell-ext.json"
 - "@cspell/dict-docker/cspell-ext.json"
 
+languageSettings:
+  - languageId: markdown
+    ignoreRegExpList:
+      - markdown_code_block
+      - markdown_inline_code
+
+
+patterns:
+  - name: markdown_code_block
+    pattern: |
+      /
+          ^(\s*`{3,}).*     # match the ```
+          [\s\S]*?          # the block of code
+          ^\1               # end of the block
+      /gmx
+  - name: markdown_inline_code
+    pattern: |
+      `[^`]*`
+
 flagWords:
 # Write "quasi-closed" instead of "quasi closed".
 - quasi

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -34,7 +34,9 @@ import:
 - "@cspell/dict-docker/cspell-ext.json"
 
 languageSettings:
-- languageId: markdown
+- languageId:
+  - markdown
+  - mdx
   ignoreRegExpList:
   - markdown_code_block
   - markdown_inline_code

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -34,23 +34,22 @@ import:
 - "@cspell/dict-docker/cspell-ext.json"
 
 languageSettings:
-  - languageId: markdown
-    ignoreRegExpList:
-      - markdown_code_block
-      - markdown_inline_code
-
+- languageId: markdown
+  ignoreRegExpList:
+  - markdown_code_block
+  - markdown_inline_code
 
 patterns:
-  - name: markdown_code_block
-    pattern: |
-      /
-          ^(\s*`{3,}).*     # match the ```
-          [\s\S]*?          # the block of code
-          ^\1               # end of the block
-      /gmx
-  - name: markdown_inline_code
-    pattern: |
-      `[^`]*`
+- name: markdown_code_block
+  pattern: |
+    /
+        ^(\s*`{3,}).*     # match the ```
+        [\s\S]*?          # the block of code
+        ^\1               # end of the block
+    /gmx
+- name: markdown_inline_code
+  pattern: |
+    `[^`]*`
 
 flagWords:
 # Write "quasi-closed" instead of "quasi closed".

--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -1,11 +1,5 @@
 ---
 sidebar_label: Release Manager Guide
-
-# Custom words specific to this page:
-# cSpell:ignore protoroot codesigningkey lockdir pinentry gpgconf orgapacheozone
-
-# On this page, ignore CLI options used with -D or -P.
-# cSpell:ignoreRegExp -(D|P)[a-z\.,]+([\s]|=)
 ---
 
 # Apache Release Manager Guide


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now docs frequently have to add inline spelling ignores to code blocks, especially for command line flags like `-Doption`. The [CSpell docs](https://cspell.org/configuration/patterns/) provide an example pattern to match multi-line markdown code blocks and only apply it to markdown files. We can add this and a similar pattern to ignore inline code blocks and remove all current inline cspell directives from the docs, since they were only needed for code blocks.

## What is the link to the Apache Jira?

HDDS-11970

## How was this patch tested?

- [This run](https://github.com/errose28/ozone-site/actions/runs/12422398675) shows [notaword](https://github.com/errose28/ozone-site/commit/374b54098f5c09b52be9a29937bf32c4fd32121e) correctly being flagged by cspell.
- [This run](https://github.com/errose28/ozone-site/actions/runs/12422422447) shows "notaword" being ignored in [various types of code blocks](https://github.com/errose28/ozone-site/commit/9df608041d5806709edaf151d3bd298a50413f8e)
- [This run](https://github.com/errose28/ozone-site/actions/runs/12422627446) shows "notaword" also being ignored in code for [mdx files](https://github.com/errose28/ozone-site/commit/f347132da497d15368d8bbf5cc4bf1db3030d9b3).
