### PR TITLE
HDDS-11979. Fix heading and list checks in markdownlint.

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -18,6 +18,7 @@
 # This file extends the defaults present in
 # https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
 
+# Only use # characters to indicate headings
 heading-style:
   style: atx
 

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -18,8 +18,7 @@
 # This file extends the defaults present in
 # https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
 
-# Headings must use # characters at the beginning of the line only, and cannot increment by more than one.
-heading-increment:
+heading-style:
   style: atx
 
 # Only - (dash) character is allowed for bullet lists.

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -18,8 +18,12 @@
 # This file extends the defaults present in
 # https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
 
-# Only - (dash) character is allowed for bullet lists.
+# Headings must use # characters at the beginning of the line only, and cannot increment by more than one.
 heading-increment:
+  style: atx
+
+# Only - (dash) character is allowed for bullet lists.
+ul-style:
   style: dash
 
 line-length:


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current markdownlint configuration has a typo that mixes the settings for headings and unordered lists:
- [heading-increment](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md001---heading-levels-should-only-increment-by-one-level-at-a-time) uses sensible default values, it does not need to be added to the config
- [heading-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md003---heading-style) should be specified as `atx` only
- [ul-style](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md004---unordered-list-style) should be `dash`. This config was incorrectly put under `heading-increment`

This was noticed during the review of #116, where `*` for lists was not flagged.

## What is the link to the Apache Jira?

HDDS-1197.

## How was this patch tested?

Check off which of the following tests were done on this change. If additional testing was done, please elaborate here as well.

- [x] The CI checks on my fork are passing
  - [This run](https://github.com/errose28/ozone-site/actions/runs/12587453973) shows existing pages already conform to these rules
- [ ] I verified the rendered content using a local preview
- [x] I manually verified the steps provided in this change work as described
  - [This run](https://github.com/errose28/ozone-site/actions/runs/12587499424/job/35083469900) adds a failing file and shows `heading-style`, `heading-increment`, and `ul-style` getting flagged
