### PR TITLE
HDDS-12128. Disable indexing of the under-construction site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,7 +30,8 @@ const darkCodeTheme = themes.dracula;
 const config = {
   title: 'Apache Ozone',
   tagline: 'Scalable, reliable, distributed storage system optimized for data analytics and object store workloads.',
-
+  // TODO: HDDS-12129 Delete this before the site goes live to enable search engine indexing.
+  noIndex: true,
   // Set the production URL of the website. Must be updated when the final site is deployed.
   // This must match the URL the website is hosted at for social media previews to work.
   // If you are testing the social media image (themeConfig.image) locally, set this to http://localhost:3001.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not allow search engines to index the under-construction website.
We do this by updating the HTML headers to `<meta name="robots" content="noindex, nofollow">`
via https://docusaurus.io/docs/api/docusaurus-config#noIndex

## What is the link to the Apache Jira?
https://issues.apache.org/jira/browse/HDDS-12128

## How was this patch tested?

Check off which of the following tests were done on this change. If additional testing was done, please elaborate here as well.

- [X] The CI checks on my fork are passing: https://github.com/ptlrs/ozone-site/actions/runs/12939447297
- [X] I verified the rendered content using a local preview
- [ ] I manually verified the steps provided in this change work as described
