### PR TITLE
HDDS-12597. Enforce "column family" without hyphen in spell check

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -36,6 +36,8 @@ import:
 flagWords:
 # Write "quasi-closed" instead of "quasi closed".
 - quasi
+# RocksDB docs do not hyphenate this term.
+- column-family
 
 # List of words to be always considered correct.
 # Case insensitive.


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the [RocksDB docs](https://github.com/facebook/rocksdb/wiki/column-families) "column family" is not hyphenated. Add this check to the website's spell checker.

## What is the link to the Apache Jira?

HDDS-12597

## How was this patch tested?

Check off which of the following tests were done on this change. If additional testing was done, please elaborate here as well.

- [x] The CI checks on my fork are passing
- [ ] I verified the rendered content using a local preview (N/A, static check only)
- [x] I manually verified the steps provided in this change work as described.

Here is a manual test that "column-family" is flagged but "column family" is not.

![Screenshot 2025-03-13 at 8 22 57 PM](https://github.com/user-attachments/assets/dca80872-cfd6-4149-babe-533530dcaf72)

