### PR TITLE
HDDS-11938. Add overview/docs landing page

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -87,3 +87,5 @@ words:
 - UX
 - devs
 - CLI
+- serializability
+- lakehouse

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -31,7 +31,7 @@ Ozone combines the best aspects of traditional distributed file systems with clo
 
 - **Strong Authentication**: Integrates with [Kerberos authentication](administrator-guide/configuration/security/kerberos) for robust security
 - **Fine-Grained Authorization**: Support for both native ACLs and [Apache Ranger integration](administrator-guide/configuration/security/ranger) for centralized authorization policies
-- **Encryption**: Transparent data encryption at rest and in-flight to protect sensitive information
+- **Encryption**: Transparent data encryption [at rest](administrator-guide/configuration/security/encryption/transparent-data-encryption) and [in-flight](administrator-guide/configuration/security/encryption/network-encryption) to protect sensitive information
 
 ### Robust Data Management
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -9,7 +9,7 @@ slug: /
 
 Apache Ozone is a scalable, reliable, distributed storage system optimized for data analytics and object store workloads. Designed to address the limitations of traditional storage systems, Ozone efficiently scales to petabytes of data and billions of objects while managing both small and large files.
 
-As a modern storage solution for data lakes and AI/ML workloads, Ozone provides a high-performance foundation that seamlessly integrates with existing big data frameworks. Applications built on Apache Spark, Hive, Hadoop, and other data processing engines work natively with Ozone without modifications.
+As a modern storage solution for data lakes and AI workloads, Ozone provides a high-performance foundation that seamlessly integrates with existing big data frameworks. Applications like Apache Spark, Hive, Hadoop, and other data processing engines work natively with Ozone without modifications.
 
 Ozone combines the best aspects of traditional distributed file systems with cloud-native object storage capabilities, delivering durability, consistency, and performance at scale.
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -74,4 +74,4 @@ When a client writes data, Ozone stores it on Datanodes in chunks called blocks,
 
 ## Getting Started
 
-To get started with Ozone, see the [Quick Start Guide](./02-quick-start/01-installation/01-docker.md) for installation instructions and basic usage examples.
+To get started with Ozone, see the [Quick Start Guide](quick-start) for installation instructions and basic usage examples.

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -30,7 +30,7 @@ Ozone combines the best aspects of traditional distributed file systems with clo
 ### Enterprise-Ready Security
 
 - **Strong Authentication**: Integrates with [Kerberos authentication](administrator-guide/configuration/security/kerberos) for robust security
-- **Fine-Grained Authorization**: Support for both native ACLs and Apache Ranger integration for centralized authorization policies
+- **Fine-Grained Authorization**: Support for both native ACLs and [Apache Ranger integration](administrator-guide/configuration/security/ranger) for centralized authorization policies
 - **Encryption**: Transparent data encryption at rest and in-flight to protect sensitive information
 
 ### Robust Data Management

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -56,7 +56,7 @@ Ozone combines the best aspects of traditional distributed file systems with clo
 Ozone has a layered architecture that separates namespace management from block space management:
 
 - **Ozone Manager (OM)**: Manages the namespace hierarchy (volumes, buckets, and keys) and handles client metadata operations
-- **Storage Container Manager (SCM)**: Manages the containers where data is stored and handles block allocation
+- **Storage Container Manager (SCM)**: Manages storage containers which contain block data and handles block allocation
 - **Datanodes**: Store the actual data in containers and provide read and write access
 - **Recon**: Analytics and monitoring service that provides insight into the cluster
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -5,8 +5,73 @@ slug: /
 
 # Overview
 
-**TODO:** [HDDS-9864](https://issues.apache.org/jira/browse/HDDS-9864) complete this page
-
 ## What is Ozone?
 
-## Features
+Apache Ozone is a scalable, redundant, and distributed object storage system optimized for big data workloads. Designed to address the limitations of traditional storage systems, Ozone efficiently manages both small and large files alike, scaling to billions of objects of varying sizes.
+
+As a modern storage solution for data lakes and AI/ML workloads, Ozone provides a high-performance foundation that seamlessly integrates with existing big data frameworks. Applications built on Apache Spark, Hive, Hadoop, and other data processing engines work natively with Ozone without modifications.
+
+Ozone combines the best aspects of traditional distributed file systems with cloud-native object storage capabilities, delivering durability, consistency, and performance at scale.
+
+## Key Features
+
+### Scalable Architecture
+
+- **Billions of Objects**: Designed from the ground up to store and manage billions of objects efficiently
+- **Separation of Namespaces**: Decouples namespace management from block space management, allowing independent scaling on both axes
+- **Dense Storage Support**: Optimized for high-density storage nodes with support for up to 400TB per node (compared to 100TB in traditional HDFS)
+
+### Multi-Protocol Support
+
+- **S3 Compatible API**: Native support for the Amazon S3 API, enabling seamless integration with S3-compatible tools and applications
+- **Hadoop Compatible File System**: Provides a filesystem interface that works with existing Hadoop ecosystem applications
+- **Rich API Options**: Supports multiple client interfaces including Java API, command-line tools, and REST endpoints
+
+### Enterprise-Ready Security
+
+- **Strong Authentication**: Integrated Kerberos authentication with robust security mechanisms
+- **Fine-Grained Authorization**: Support for both native ACLs and Apache Ranger integration for centralized authorization policies
+- **Encryption**: Transparent data encryption at rest and in-flight to protect sensitive information
+
+### Robust Data Management
+
+- **Strong Consistency**: Provides strict serializability to simplify application design and ensure data integrity
+- **Metadata Management**: Efficient handling of metadata with dedicated services for high performance 
+- **Snapshots**: Support for point-in-time snapshots to protect against data corruption and facilitate backups
+
+### Operational Excellence
+
+- **Fault Tolerance**: Designed for resiliency with automatic recovery mechanisms to handle failures at all levels
+- **Observability**: Comprehensive metrics, logging, and monitoring through web UI, Prometheus integration, and Grafana dashboards
+- **Replication and Erasure Coding**: Flexible data protection strategies to balance storage efficiency and durability requirements
+
+### Integration with Data Analytics Ecosystem
+
+- **Hadoop Ecosystem**: Seamless integration with Hadoop, Hive, and Spark workloads
+- **SQL Engines**: Works with SQL query engines like Hive, Impala, and Trino without modification
+- **Modern Data Formats**: Supports modern table formats like Apache Iceberg for data lakehouse architectures
+
+## Architecture Overview
+
+Ozone has a layered architecture that separates namespace management from storage management:
+
+- **Ozone Manager (OM)**: Manages the namespace hierarchy (volumes, buckets, and keys) and handles client metadata operations
+- **Storage Container Manager (SCM)**: Manages the containers where data is stored and handles block allocation
+- **DataNodes**: Store the actual data in containers and provide read and write access
+- **Recon**: Analytics and monitoring service that provides insight into the cluster
+
+This separation allows Ozone to achieve the scale required for modern storage systems while maintaining high performance and reliability.
+
+## Storage Elements
+
+Ozone organizes storage in a three-level hierarchy:
+
+- **Volumes**: Similar to accounts, created by administrators for organizations or teams
+- **Buckets**: Created by users within volumes, similar to S3 buckets
+- **Keys**: Data objects stored inside buckets, each potentially containing multiple blocks
+
+When a client writes data, Ozone stores it on DataNodes in chunks called blocks, which are organized into containers for efficient management and replication.
+
+## Getting Started
+
+To get started with Ozone, see the [Quick Start Guide](./02-quick-start/01-installation/01-docker.md) for installation instructions and basic usage examples.

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -53,7 +53,7 @@ Ozone combines the best aspects of traditional distributed file systems with clo
 
 ## Architecture Overview
 
-Ozone has a layered architecture that separates namespace management from storage management:
+Ozone has a layered architecture that separates namespace management from block space management:
 
 - **Ozone Manager (OM)**: Manages the namespace hierarchy (volumes, buckets, and keys) and handles client metadata operations
 - **Storage Container Manager (SCM)**: Manages the containers where data is stored and handles block allocation

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -29,7 +29,7 @@ Ozone combines the best aspects of traditional distributed file systems with clo
 
 ### Enterprise-Ready Security
 
-- **Strong Authentication**: Integrated Kerberos authentication with robust security mechanisms
+- **Strong Authentication**: Integrates with [Kerberos authentication](administrator-guide/configuration/security/kerberos) for robust security
 - **Fine-Grained Authorization**: Support for both native ACLs and Apache Ranger integration for centralized authorization policies
 - **Encryption**: Transparent data encryption at rest and in-flight to protect sensitive information
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -60,7 +60,7 @@ Ozone has a layered architecture that separates namespace management from block 
 - **Datanodes**: Store the actual data in containers and provide read and write access
 - **Recon**: Analytics and monitoring service that provides insight into the cluster
 
-This separation allows Ozone to achieve the scale required for modern storage systems while maintaining high performance and reliability.
+This separation allows Ozone to achieve the scale required of modern storage systems while maintaining high performance and reliability.
 
 ## Storage Elements
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -35,8 +35,8 @@ Ozone combines the best aspects of traditional distributed file systems with clo
 
 ### Robust Data Management
 
-- **Strong Consistency**: Provides strict serializability to simplify application design and ensure data integrity
-- **Metadata Management**: Efficient handling of metadata with dedicated services for high performance 
+- **Strong Consistency**: Provides strict consistency to simplify application design and ensure data integrity
+- **Metadata Management**: Efficient handling of metadata with dedicated services for high performance
 - **Snapshots**: Support for point-in-time snapshots to protect against data corruption and facilitate backups
 
 ### Operational Excellence
@@ -49,7 +49,7 @@ Ozone combines the best aspects of traditional distributed file systems with clo
 
 - **Hadoop Ecosystem**: Seamless integration with Hadoop, Hive, and Spark workloads
 - **SQL Engines**: Works with SQL query engines like Hive, Impala, and Trino without modification
-- **Modern Data Formats**: Supports modern table formats like Apache Iceberg for data lakehouse architectures
+- **Modern Data Formats**: Supports modern table formats like Apache Iceberg for data lake architectures
 
 ## Architecture Overview
 
@@ -57,7 +57,7 @@ Ozone has a layered architecture that separates namespace management from storag
 
 - **Ozone Manager (OM)**: Manages the namespace hierarchy (volumes, buckets, and keys) and handles client metadata operations
 - **Storage Container Manager (SCM)**: Manages the containers where data is stored and handles block allocation
-- **DataNodes**: Store the actual data in containers and provide read and write access
+- **Datanodes**: Store the actual data in containers and provide read and write access
 - **Recon**: Analytics and monitoring service that provides insight into the cluster
 
 This separation allows Ozone to achieve the scale required for modern storage systems while maintaining high performance and reliability.
@@ -70,7 +70,7 @@ Ozone organizes storage in a three-level hierarchy:
 - **Buckets**: Created by users within volumes, similar to S3 buckets
 - **Keys**: Data objects stored inside buckets, each potentially containing multiple blocks
 
-When a client writes data, Ozone stores it on DataNodes in chunks called blocks, which are organized into containers for efficient management and replication.
+When a client writes data, Ozone stores it on Datanodes in chunks called blocks, which are organized into containers for efficient management and replication.
 
 ## Getting Started
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -70,7 +70,7 @@ Ozone organizes storage in a three-level hierarchy:
 - **Buckets**: Created by users within volumes, similar to S3 buckets
 - **Keys**: Data objects stored inside buckets, each potentially containing multiple blocks
 
-When a client writes data, Ozone stores it on Datanodes in chunks called blocks, which are organized into containers for efficient management and replication.
+When a client writes data, Ozone stores it as blocks on the Datanodes, which are organized into storage containers for efficient management and replication.
 
 ## Getting Started
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -68,7 +68,7 @@ Ozone organizes storage in a three-level hierarchy:
 
 - **Volumes**: Similar to accounts, created by administrators for organizations or teams
 - **Buckets**: Created by users within volumes, similar to S3 buckets
-- **Keys**: Data objects stored inside buckets, each potentially containing multiple blocks
+- **Keys**: Data objects stored inside buckets comprised of multiple blocks
 
 When a client writes data, Ozone stores it as blocks on the Datanodes, which are organized into storage containers for efficient management and replication.
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -7,7 +7,7 @@ slug: /
 
 ## What is Ozone?
 
-Apache Ozone is a scalable, redundant, and distributed object storage system optimized for big data workloads. Designed to address the limitations of traditional storage systems, Ozone efficiently manages both small and large files alike, scaling to billions of objects of varying sizes.
+Apache Ozone is a scalable, reliable, distributed storage system optimized for data analytics and object store workloads. Designed to address the limitations of traditional storage systems, Ozone efficiently scales to petabytes of data and billions of objects while managing both small and large files.
 
 As a modern storage solution for data lakes and AI/ML workloads, Ozone provides a high-performance foundation that seamlessly integrates with existing big data frameworks. Applications built on Apache Spark, Hive, Hadoop, and other data processing engines work natively with Ozone without modifications.
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -18,7 +18,7 @@ Ozone combines the best aspects of traditional distributed file systems with clo
 ### Scalable Architecture
 
 - **Billions of Objects**: Designed from the ground up to store and manage billions of objects efficiently
-- **Separation of Namespaces**: Decouples namespace management from block space management, allowing independent scaling on both axes
+- **Separation of Namespaces**: Decouples namespace management from block space management, allowing the cluster to scale with capacity regardless of file sizes
 - **Dense Storage Support**: Optimized for high-density storage nodes with support for up to 400TB per node (compared to 100TB in traditional HDFS)
 
 ### Multi-Protocol Support


### PR DESCRIPTION
## What changes were proposed in this pull request?

    
      - Add comprehensive 'What is Ozone?' section focusing on modern data lake and AI storage use cases
      - Organize features into logical categories with detailed descriptions
      - Add architecture overview section explaining key components
      - Include storage elements section explaining the hierarchy
      - Add getting started section with link to quick start guide
    
      Fixes: HDDS-9864
    
      This message highlights the key improvements while emphasizing the modern positioning of Ozone for data lakes and AI workloads rather than just Hadoop integration.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-9864

## How was this patch tested?

Check off which of the following tests were done on this change. If additional testing was done, please elaborate here as well.

- [X] The CI checks on my fork are passing
- [X] I verified the rendered content using a local preview
- [ ] I manually verified the steps provided in this change work as described
