### PR TITLE
HDDS-12673. Streamline pre-vote Subversion instructions

### DIFF
--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -341,11 +341,11 @@ Before uploading the artifacts, run some basic tests on them, similar to what ot
 1. Upload everything from the `$RELEASE_DIR` to the dev staging area.
 
     ```bash
-    svn mkdir https://dist.apache.org/repos/dist/dev/ozone/"$VERSION-rc$RC"
-    svn co https://dist.apache.org/repos/dist/dev/ozone/"$VERSION-rc$RC"
-    cp "$RELEASE_DIR"/* "$VERSION-rc$RC"
-    cd "$VERSION-rc$RC"
-    svn add *
+    svn checkout https://dist.apache.org/repos/dist/dev/ozone
+    cd ozone
+    mkdir "$VERSION-rc$RC"
+    cp -v "$RELEASE_DIR"/* "$VERSION-rc$RC"/
+    svn add "$VERSION-rc$RC"
     svn commit -m "Ozone $VERSION RC$RC"
     ```
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update pre-vote Subversion instructions to commit the RC in one step.  In the current version, `svn mkdir https://...` creates the directory in Subversion as a separate commit.

https://issues.apache.org/jira/browse/HDDS-12673

https://github.com/adoroszlai/ozone-site/actions/runs/14017470410
