### PR TITLE
HDDS-13498. [Ozone 2.1] Publish javadoc.

### DIFF
--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -266,7 +266,7 @@ If the command fails on MacOS, you may need to do the following additional steps
 Build the project to fetch dependencies.
 
   ```bash
-  mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname="$CODESIGNINGKEY"
+  mvn clean install -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname="$CODESIGNINGKEY"
   ```
 
 ### Create and Upload Maven Artifacts
@@ -274,7 +274,7 @@ Build the project to fetch dependencies.
 - Perform the final build and upload the release artifacts.
 
   ```bash
-  mvn deploy -DdeployAtEnd=true -Dmaven.javadoc.skip=true -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname="$CODESIGNINGKEY"
+  mvn deploy -DdeployAtEnd=true -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname="$CODESIGNINGKEY"
   ```
 
 - Go to https://repository.apache.org/#stagingRepositories and **close** the newly created `orgapacheozone` repository.


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-13498. [Ozone 2.1] Publish javadoc.

Please describe your PR in detail:
- Include javadocs in the release build

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-13498

## How was this patch tested?

Check off which of the following tests were done on this change. If additional testing was done, please elaborate here as well.

- [ ] The CI checks on my fork are passing
- [ ] I verified the rendered content using a local preview
- [ ] I manually verified the steps provided in this change work as described
