### PR TITLE
HDDS-13700. Add Information about Building on ARM-based Macs to web site

### DIFF
--- a/docs/08-developer-guide/01-build/01-maven.md
+++ b/docs/08-developer-guide/01-build/01-maven.md
@@ -47,7 +47,7 @@ Apache Ozone uses [Maven](https://maven.apache.org/) as its build system. The bu
 
 ### Additional Steps Required For ARM-based Apple Silicon Macs (M1, etc)
 
-If you are running on an ARM-based Apple Silicon Mac, please perform the additional steps in this section.
+If you are running on an ARM-based Apple silicon Mac, please perform the additional steps in this section.
 
 #### Compile and Patch Protobuf version 2.5.0 for ARM-based Mac
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-13700. Add Information about Building on ARM-based Macs to web site

Please describe your PR in detail:
- Added specific instructions about building Ozone on ARM-based Apple Silicon Macs to the new website.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-13700

## How was this patch tested?

Check off which of the following tests were done on this change. If additional testing was done, please elaborate here as well.

- [ ] The CI checks on my fork are passing
- [ ] I verified the rendered content using a local preview
- [X] I manually verified the steps provided in this change work as described
