### PR TITLE
HDDS-14082. Add Hue integration guide and verification compose stack

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -198,6 +198,7 @@ words:
 - lakehouse
 - lakehouses
 - Flink
+- filepicker
 - rebalancing
 - JDK
 - CMDB

--- a/docs/04-user-guide/02-integrations/02-hue.md
+++ b/docs/04-user-guide/02-integrations/02-hue.md
@@ -1,8 +1,164 @@
 ---
-draft: true
+sidebar_label: Hue
 ---
 
 # Hue
 
-**TODO:** File a subtask under [HDDS-9858](https://issues.apache.org/jira/browse/HDDS-9858) and complete this page or section.
-**TODO:** Uncomment link to this page in src/pages/index.js
+[Cloudera Hue](https://docs.gethue.com/) provides a web interface for browsing files, running SQL, and working with data across many storage and query engines. Hue's **File Browser** can browse Apache Ozone volumes, buckets, and paths when Ozone is exposed through the **Ozone HttpFS gateway** and its WebHDFS-compatible REST API.
+
+Hue does **not** browse Ozone through the Ozone Manager (OM) HTTP endpoint or through the Ozone S3 Gateway. HttpFS is a separate Ozone role; see the [HttpFS Gateway](../client-interfaces/httpfs) documentation.
+
+## Architecture
+
+```text
+Cloudera Hue (File Browser) --WebHDFS REST--> Ozone HttpFS gateway --Ozone RPC--> Ozone Manager
+```
+
+## Prerequisites
+
+- A running Ozone cluster with the **HttpFS** role enabled.
+- Network connectivity from the Hue server to the HttpFS host and port (Docker Compose exposes HttpFS on port **14000** by default).
+- For secure clusters: Kerberos (SPNEGO) on HttpFS and TLS as required by your deployment.
+
+To try the steps locally, start an Ozone cluster with Docker Compose as described in the [Docker quick start](../../quick-start/installation/docker) or [developer Docker Compose guide](../../developer-guide/run/docker-compose). The default stack includes an `httpfs` service on `localhost:14000`.
+
+## Configure HttpFS
+
+Ensure the HttpFS gateway is running and reachable at `http(s)://<httpfs-host>:<port>/webhdfs/v1`.
+
+### Proxy user for Hue
+
+Hue runs as a service user (for example `hue`) and performs File Browser operations on behalf of the logged-in Hue user. Configure HttpFS proxy-user settings in **`httpfs-site.xml`**, not in OM `core-site.xml`. See [Proxy User Configuration](../client-interfaces/httpfs#proxy-user-configuration) and [apache/ozone#9596](https://github.com/apache/ozone/pull/9596) (HDDS-14352).
+
+Replace `hue` with the OS user that runs the Hue process:
+
+```xml
+<property>
+  <name>httpfs.proxyuser.hue.hosts</name>
+  <value>*</value>
+</property>
+<property>
+  <name>httpfs.proxyuser.hue.groups</name>
+  <value>*</value>
+</property>
+```
+
+Restrict `hosts` and `groups` in production instead of using `*`. Restart HttpFS after changing `httpfs-site.xml`.
+
+On Docker Compose, you can set the same properties through HttpFS environment variables (for example `CORE-SITE.XML_httpfs.proxyuser.hue.hosts=*`).
+
+### Verify HttpFS with curl
+
+Before configuring Hue, confirm WebHDFS works against your HttpFS gateway:
+
+```bash
+# Create a volume
+curl -i -X PUT "http://localhost:14000/webhdfs/v1/huevol?op=MKDIRS&user.name=hdfs"
+
+# Create a bucket
+curl -i -X PUT "http://localhost:14000/webhdfs/v1/huevol/huebucket?op=MKDIRS&user.name=hdfs"
+
+# List the bucket
+curl -i "http://localhost:14000/webhdfs/v1/huevol/huebucket?op=LISTSTATUS&user.name=hdfs"
+```
+
+Additional examples are in [HttpFS Gateway](../client-interfaces/httpfs#getting-started).
+
+## Configure Hue (`hue.ini`)
+
+Add an Ozone filesystem definition under `[[ozone]]` / `[[[default]]]`. Put `fs_defaultfs` in that nested block, not under `[desktop]`. The `webhdfs_url` must point at the **HttpFS gateway**, not the OM HTTP port (`9874`).
+
+Non-secure cluster example:
+
+```ini
+[desktop]
+# Ozone does not support the /append WebHDFS API; disable chunked uploads.
+enable_chunked_file_uploader=false
+
+[[ozone]]
+[[[default]]]
+fs_defaultfs=ofs://om
+webhdfs_url=http://httpfs:14000/webhdfs/v1
+```
+
+- **`fs_defaultfs`**: Use `ofs://<service-id>` for HA (`ozone.service.id`) or `ofs://<om-host>` for a single OM. Docker Compose uses `ofs://om`.
+- **`webhdfs_url`**: HttpFS WebHDFS base URL, for example `http://localhost:14000/webhdfs/v1` from the host or `http://httpfs:14000/webhdfs/v1` on the Docker network.
+
+Secure cluster additions:
+
+```ini
+[[ozone]]
+[[[default]]]
+fs_defaultfs=ofs://ozonecluster
+webhdfs_url=https://httpfs-host.example.com:14000/webhdfs/v1
+security_enabled=true
+ssl_cert_ca_verify=true
+```
+
+Optional settings from the [Cloudera Hue Ozone guide](https://docs.cloudera.com/cdp-private-cloud-base/7.1.9/administering-hue/topics/hue-browse-ozone-fs.html):
+
+- **`upload_chunk_size`**: Increase the upload chunk size (in bytes) for large files. Default is 64 MB.
+- **`[[[default]]]` `nice_name`**: Display name for the Ozone filesystem in Hue.
+
+Restart Hue after editing `hue.ini`.
+
+## Hue user permissions
+
+After Ozone is configured in `hue.ini`, grant users access to the Ozone File Browser. Log in to Hue as an administrator, open **Administer Users**, go to the **Groups** tab, select the target group, and enable:
+
+`filebrowser.ofs_access` — Access to OFS from filebrowser and filepicker
+
+Click **Update group** to save. Non-admin users cannot browse Ozone until this permission is granted to their group. See the [Cloudera Hue Ozone guide](https://docs.cloudera.com/cdp-private-cloud-base/7.1.9/administering-hue/topics/hue-browse-ozone-fs.html).
+
+## Using Hue with Ozone
+
+After HttpFS, `hue.ini`, and permissions are configured:
+
+1. Sign in to Hue and open **File Browser**.
+2. Select the **Ozone** filesystem in the left navigation.
+3. Browse volumes, buckets, and directories (especially in **FSO** buckets).
+4. Upload, download, create directories, and perform other supported file operations subject to Ozone ACLs and Hue limitations below.
+
+Query engines integrated with Hue (for example Hive or Impala) can reference `ofs://` paths in table `LOCATION` values when `fs_defaultfs` is set correctly. See [Hive](./hive) for Ozone table examples.
+
+## Limitations
+
+Hue supports browsing Ozone through HttpFS, but some operations are limited. See the [Cloudera limitations documentation](https://docs-archive.cloudera.com/cdw-runtime/1.5.1/administering-hue/topics/hue-browse-ozone-fs-limitations.html).
+
+- **Copy size**: Hue skips files larger than the upload chunk size (default 64 MB) when copying directories recursively. Increase `upload_chunk_size` in `hue.ini` if needed.
+- **Append / chunked upload**: Ozone does not implement WebHDFS `/append`. Set `enable_chunked_file_uploader=false` so Hue uploads each file as a single chunk.
+- **User home**: Users default to the `ofs://` root when opening Ozone in File Browser.
+- **Volumes and buckets**: Hue can create the default volume and bucket only; other volume/bucket management uses the Ozone CLI or Recon.
+- **Erasure Coding**: Hue cannot create EC-enabled buckets. Create EC buckets with the Ozone CLI and browse them from Hue.
+
+## Bucket layout
+
+- **FSO (recommended)**: File System Optimized buckets provide hierarchical directories and work best with Hue File Browser over HttpFS/WebHDFS.
+- **OBS**: Object Store buckets use a flat key namespace. Hue File Browser is intended for filesystem semantics over HttpFS; use FSO buckets for directory-oriented browsing.
+
+## Troubleshooting
+
+### Cannot connect / "Could not connect to WebHDFS"
+
+- Confirm `webhdfs_url` points to the **HttpFS** gateway (`/webhdfs/v1`), not OM port `9874`.
+- Check network connectivity and firewalls between Hue and HttpFS.
+- Verify HttpFS is running and responds to curl `LISTSTATUS` (see [Configure HttpFS](#configure-httpfs)).
+- Review HttpFS logs for errors.
+
+### Authentication errors (secure clusters)
+
+- Verify HttpFS Kerberos principal and keytab configuration.
+- Set `security_enabled=true` in the `[[[default]]]` Ozone block when HttpFS uses SPNEGO.
+- For TLS, set `ssl_cert_ca_verify` and provide CA certificates as required.
+
+### Permission denied / impersonation errors
+
+- Verify `httpfs.proxyuser.<hue_user>.hosts` and `httpfs.proxyuser.<hue_user>.groups` in `httpfs-site.xml`.
+- Ensure the **end user** (not only the Hue service user) has Ozone ACLs on the target path.
+- Confirm the user's Hue group has `filebrowser.ofs_access`.
+
+### File operations fail
+
+- Check Ozone ACLs and Ranger policies for the impersonated user.
+- Prefer **FSO** buckets for directory create, rename, and delete operations.
+- Check HttpFS and OM logs for the specific WebHDFS operation that failed.

--- a/docs/04-user-guide/02-integrations/02-hue.md
+++ b/docs/04-user-guide/02-integrations/02-hue.md
@@ -58,10 +58,17 @@ Hue also issues proxied Ozone RPC calls through HttpFS. Configure matching `hado
 
 Restrict `hosts` and `groups` in production instead of using `*`. Restart HttpFS after changing `httpfs-site.xml`.
 
-On Docker Compose, you can set the same properties through HttpFS environment variables (for example `CORE-SITE.XML_httpfs.proxyuser.hue.hosts=*`). HttpFS runs as the `hadoop` OS user; WebHDFS requests that pass `user.name` (including the curl checks below) require both:
+On Docker Compose, set proxy-user properties on the **HttpFS** container with the `HTTPFS-SITE.XML_` prefix (they belong in `httpfs-site.xml`, not `core-site.xml`):
 
-- `httpfs.proxyuser.hadoop.hosts` and `httpfs.proxyuser.hadoop.groups` in HttpFS `httpfs-site.xml` (or `CORE-SITE.XML_httpfs.proxyuser.hadoop.*` on the HttpFS container)
-- `hadoop.proxyuser.hadoop.hosts` and `hadoop.proxyuser.hadoop.groups` in OM `core-site.xml` (or `CORE-SITE.XML_hadoop.proxyuser.hadoop.*` on the OM container) so OM accepts proxied RPC calls from HttpFS
+```bash
+HTTPFS-SITE.XML_httpfs.proxyuser.hue.hosts=*
+HTTPFS-SITE.XML_httpfs.proxyuser.hue.groups=*
+```
+
+HttpFS runs as the `hadoop` OS user. WebHDFS curl checks that pass `user.name=hadoop` (or another proxy user) also require:
+
+- `HTTPFS-SITE.XML_httpfs.proxyuser.hadoop.hosts` and `HTTPFS-SITE.XML_httpfs.proxyuser.hadoop.groups` on the HttpFS container
+- `CORE-SITE.XML_hadoop.proxyuser.hadoop.hosts` and `CORE-SITE.XML_hadoop.proxyuser.hadoop.groups` on the OM container so OM accepts proxied RPC calls from HttpFS
 
 ### Verify HttpFS with curl
 
@@ -204,7 +211,8 @@ The bundled `static/compose/hue-ozone/hue.ini` already disables HDFS and YARN fo
 
 ### Permission denied / impersonation errors
 
-- Verify `httpfs.proxyuser.<hue_user>.hosts` and `httpfs.proxyuser.<hue_user>.groups` in `httpfs-site.xml`.
+- Verify `httpfs.proxyuser.<hue_user>.hosts` and `httpfs.proxyuser.<hue_user>.groups` in **`httpfs-site.xml`** (on Docker Compose, use `HTTPFS-SITE.XML_httpfs.proxyuser.<hue_user>.*` on the HttpFS container — not `CORE-SITE.XML_`).
+- If Hue reports `User: hue is not allowed to impersonate admin`, HttpFS is missing or not reading the Hue proxy-user settings; recreate the HttpFS container after fixing `httpfs-site.xml`.
 - Ensure the **end user** (not only the Hue service user) has Ozone ACLs on the target path.
 - Confirm the user's Hue group has `filebrowser.ofs_access`.
 

--- a/docs/04-user-guide/02-integrations/02-hue.md
+++ b/docs/04-user-guide/02-integrations/02-hue.md
@@ -43,9 +43,14 @@ Replace `hue` with the OS user that runs the Hue process:
 </property>
 ```
 
+Hue also issues proxied Ozone RPC calls through HttpFS. Configure matching `hadoop.proxyuser.hue.hosts` and `hadoop.proxyuser.hue.groups` in OM `core-site.xml` (not only in HttpFS `httpfs-site.xml`).
+
 Restrict `hosts` and `groups` in production instead of using `*`. Restart HttpFS after changing `httpfs-site.xml`.
 
-On Docker Compose, you can set the same properties through HttpFS environment variables (for example `CORE-SITE.XML_httpfs.proxyuser.hue.hosts=*`).
+On Docker Compose, you can set the same properties through HttpFS environment variables (for example `CORE-SITE.XML_httpfs.proxyuser.hue.hosts=*`). HttpFS runs as the `hadoop` OS user; WebHDFS requests that pass `user.name` (including the curl checks below) require both:
+
+- `httpfs.proxyuser.hadoop.hosts` and `httpfs.proxyuser.hadoop.groups` in HttpFS `httpfs-site.xml` (or `CORE-SITE.XML_httpfs.proxyuser.hadoop.*` on the HttpFS container)
+- `hadoop.proxyuser.hadoop.hosts` and `hadoop.proxyuser.hadoop.groups` in OM `core-site.xml` (or `CORE-SITE.XML_hadoop.proxyuser.hadoop.*` on the OM container) so OM accepts proxied RPC calls from HttpFS
 
 ### Verify HttpFS with curl
 
@@ -162,3 +167,8 @@ Hue supports browsing Ozone through HttpFS, but some operations are limited. See
 - Check Ozone ACLs and Ranger policies for the impersonated user.
 - Prefer **FSO** buckets for directory create, rename, and delete operations.
 - Check HttpFS and OM logs for the specific WebHDFS operation that failed.
+- On Docker Compose dev clusters, the default SCM block size (256 MB) can prevent small file uploads because datanodes cannot satisfy the reserved space. Lower `ozone.scm.block.size` and `ozone.scm.container.size` in `ozone-site.xml` for local testing, as described in the [Docker Compose guide](../../developer-guide/run/docker-compose#step-3-configure-your-deployment-optional).
+
+### Volume or bucket already exists (curl verification)
+
+Re-running the HttpFS `MKDIRS` curl examples against the same volume or bucket name returns HTTP 500 with `Volume already exists` or a similar error. Use new names, or treat the response as confirmation that the path is already present.

--- a/docs/04-user-guide/02-integrations/02-hue.md
+++ b/docs/04-user-guide/02-integrations/02-hue.md
@@ -22,6 +22,15 @@ Cloudera Hue (File Browser) --WebHDFS REST--> Ozone HttpFS gateway --Ozone RPC--
 
 To try the steps locally, start an Ozone cluster with Docker Compose as described in the [Docker quick start](../../quick-start/installation/docker) or [developer Docker Compose guide](../../developer-guide/run/docker-compose). The default stack includes an `httpfs` service on `localhost:14000`.
 
+For an all-in-one **Hue + Ozone** verification stack (HttpFS, Hue, and a Postgres database for Hue users), use the compose files under [`static/compose/hue-ozone/`](https://github.com/apache/ozone-site/tree/master/static/compose/hue-ozone) in this repository:
+
+```bash
+cd static/compose/hue-ozone
+docker compose up -d --scale datanode=3
+```
+
+Hue listens on `http://localhost:8888` (default login: `admin` / `admin`). The stack includes a **Postgres** service so Hue persists users and avoids embedded-DB issues during local testing.
+
 ## Configure HttpFS
 
 Ensure the HttpFS gateway is running and reachable at `http(s)://<httpfs-host>:<port>/webhdfs/v1`.
@@ -80,11 +89,22 @@ Non-secure cluster example:
 # Ozone does not support the /append WebHDFS API; disable chunked uploads.
 enable_chunked_file_uploader=false
 
+# Local compose only: Postgres backing store for Hue users (see static/compose/hue-ozone).
+[[database]]
+engine=postgresql_psycopg2
+host=postgres
+port=5432
+user=hue
+password=hue
+name=hue
+
 [[ozone]]
 [[[default]]]
 fs_defaultfs=ofs://om
 webhdfs_url=http://httpfs:14000/webhdfs/v1
 ```
+
+- **`[[database]]`**: Optional for production CDP deployments; required in the bundled `hue-ozone` compose stack so Hue persists users in Postgres instead of an embedded database.
 
 - **`fs_defaultfs`**: Use `ofs://<service-id>` for HA (`ozone.service.id`) or `ofs://<om-host>` for a single OM. Docker Compose uses `ofs://om`.
 - **`webhdfs_url`**: HttpFS WebHDFS base URL, for example `http://localhost:14000/webhdfs/v1` from the host or `http://httpfs:14000/webhdfs/v1` on the Docker network.
@@ -168,6 +188,11 @@ Hue supports browsing Ozone through HttpFS, but some operations are limited. See
 - Prefer **FSO** buckets for directory create, rename, and delete operations.
 - Check HttpFS and OM logs for the specific WebHDFS operation that failed.
 - On Docker Compose dev clusters, the default SCM block size (256 MB) can prevent small file uploads because datanodes cannot satisfy the reserved space. Lower `ozone.scm.block.size` and `ozone.scm.container.size` in `ozone-site.xml` for local testing, as described in the [Docker Compose guide](../../developer-guide/run/docker-compose#step-3-configure-your-deployment-optional).
+
+### Hue login or user errors (local Docker)
+
+- Ensure the `postgres` service is healthy before Hue starts (`docker compose ps`).
+- Confirm `hue.ini` includes the `[[database]]` block with `engine=postgresql_psycopg2` and host `postgres`, matching the compose environment variables.
 
 ### Volume or bucket already exists (curl verification)
 

--- a/docs/04-user-guide/02-integrations/02-hue.md
+++ b/docs/04-user-guide/02-integrations/02-hue.md
@@ -27,9 +27,12 @@ For an all-in-one **Hue + Ozone** verification stack (HttpFS, Hue, and a Postgre
 ```bash
 cd static/compose/hue-ozone
 docker compose up -d --scale datanode=3
+./init-demo-data.sh
 ```
 
 Hue listens on `http://localhost:8888` (default login: `admin` / `admin`). The stack includes a **Postgres** service so Hue persists users and avoids embedded-DB issues during local testing.
+
+Run `./init-demo-data.sh` after the cluster starts. It creates `huevol` / `huevol/huebucket` owned by `admin` so the default Hue login can see them at `ofs://om`. WebHDFS `MKDIRS` alone creates volumes owned by the WebHDFS user (`hue`, `hdfs`, etc.); other Hue users see an empty Ozone root until they have **LIST** access on those volumes.
 
 In the Hue sidebar, open **Ozone** (not **Files**). **Files** is the HDFS browser and is disabled in this stack because there is no NameNode.
 
@@ -75,15 +78,20 @@ HttpFS runs as the `hadoop` OS user. WebHDFS curl checks that pass `user.name=ha
 Before configuring Hue, confirm WebHDFS works against your HttpFS gateway:
 
 ```bash
-# Create a volume
-curl -i -X PUT "http://localhost:14000/webhdfs/v1/huevol?op=MKDIRS&user.name=hdfs"
-
-# Create a bucket
-curl -i -X PUT "http://localhost:14000/webhdfs/v1/huevol/huebucket?op=MKDIRS&user.name=hdfs"
-
-# List the bucket
-curl -i "http://localhost:14000/webhdfs/v1/huevol/huebucket?op=LISTSTATUS&user.name=hdfs"
+# After ./init-demo-data.sh in static/compose/hue-ozone (creates admin-owned paths)
+curl -i "http://localhost:14000/webhdfs/v1/?op=LISTSTATUS&user.name=admin"
+curl -i "http://localhost:14000/webhdfs/v1/huevol?op=LISTSTATUS&user.name=admin"
+curl -i "http://localhost:14000/webhdfs/v1/huevol/huebucket?op=LISTSTATUS&user.name=admin"
 ```
+
+To create paths manually with the Ozone shell (recommended so you control volume owner and bucket layout):
+
+```bash
+docker compose exec om ozone sh volume create /huevol -u admin
+docker compose exec om ozone sh bucket create /huevol/huebucket --layout fso
+```
+
+WebHDFS `MKDIRS` can also create volumes and buckets, but the volume owner is the `user.name` in the request. Hue impersonates the logged-in user, so a volume created as `user.name=hue` is not listed at `ofs://om` for the `admin` Hue account unless `admin` has **LIST** ACLs on that volume.
 
 Additional examples are in [HttpFS Gateway](../client-interfaces/httpfs#getting-started).
 
@@ -208,6 +216,12 @@ The bundled `static/compose/hue-ozone/hue.ini` already disables HDFS and YARN fo
 - Verify HttpFS Kerberos principal and keytab configuration.
 - Set `security_enabled=true` in the `[[[default]]]` Ozone block when HttpFS uses SPNEGO.
 - For TLS, set `ssl_cert_ca_verify` and provide CA certificates as required.
+
+### Ozone File Browser is empty at `ofs://om`
+
+- Hue lists volumes visible to the **logged-in Hue user** (HttpFS `doas`). Volumes created with `user.name=hue` or `user.name=hdfs` are owned by that user and do not appear at the root for `admin` unless `admin` has **LIST** ACLs on the volume.
+- In `static/compose/hue-ozone`, run `./init-demo-data.sh` after `docker compose up` to recreate `huevol` / `huebucket` owned by `admin`.
+- Grant the Hue user **LIST** (or **ALL**) on the volume with `ozone sh volume setacl`, or create the volume with `ozone sh volume create /vol -u <hue-user>`.
 
 ### Permission denied / impersonation errors
 

--- a/docs/04-user-guide/02-integrations/02-hue.md
+++ b/docs/04-user-guide/02-integrations/02-hue.md
@@ -31,6 +31,8 @@ docker compose up -d --scale datanode=3
 
 Hue listens on `http://localhost:8888` (default login: `admin` / `admin`). The stack includes a **Postgres** service so Hue persists users and avoids embedded-DB issues during local testing.
 
+In the Hue sidebar, open **Ozone** (not **Files**). **Files** is the HDFS browser and is disabled in this stack because there is no NameNode.
+
 ## Configure HttpFS
 
 Ensure the HttpFS gateway is running and reachable at `http(s)://<httpfs-host>:<port>/webhdfs/v1`.
@@ -102,6 +104,17 @@ name=hue
 [[[default]]]
 fs_defaultfs=ofs://om
 webhdfs_url=http://httpfs:14000/webhdfs/v1
+nice_name=Ozone
+
+[hadoop]
+# Disable HDFS/YARN defaults; this stack uses Ozone only.
+[[hdfs_clusters]]
+[[[default]]]
+is_enabled=false
+
+[[yarn_clusters]]
+[[[default]]]
+is_enabled=false
 ```
 
 - **`[[database]]`**: Optional for production CDP deployments; required in the bundled `hue-ozone` compose stack so Hue persists users in Postgres instead of an embedded database.
@@ -162,6 +175,19 @@ Hue supports browsing Ozone through HttpFS, but some operations are limited. See
 - **OBS**: Object Store buckets use a flat key namespace. Hue File Browser is intended for filesystem semantics over HttpFS; use FSO buckets for directory-oriented browsing.
 
 ## Troubleshooting
+
+### HDFS "Files" shows `/user/admin` or port 50070 errors
+
+Hue ships with a default **HDFS** File Browser that points at `localhost:50070`. In an Ozone-only deployment there is no NameNode, so **Files** fails with connection refused. Use the **Ozone** entry in the left sidebar instead, or disable HDFS in `hue.ini`:
+
+```ini
+[hadoop]
+[[hdfs_clusters]]
+[[[default]]]
+is_enabled=false
+```
+
+The bundled `static/compose/hue-ozone/hue.ini` already disables HDFS and YARN for this reason.
 
 ### Cannot connect / "Could not connect to WebHDFS"
 

--- a/src/components/AskQuestionForm/index.jsx
+++ b/src/components/AskQuestionForm/index.jsx
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { useState } from 'react';
 import Heading from '@theme/Heading';
+import { useState } from 'react';
 import styles from './styles.module.css';
 
 export default function AskQuestionForm() {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -381,7 +381,7 @@ function Integrations() {
           }}
         />
       ),
-      // link: '/docs/user-guide/integrations/hue'
+      link: '/docs/user-guide/integrations/hue'
     },
     {
       name: "HBase",

--- a/static/compose/hue-ozone/docker-compose.hue-only.yaml
+++ b/static/compose/hue-ozone/docker-compose.hue-only.yaml
@@ -26,6 +26,19 @@
 #   CORE-SITE.XML_httpfs.proxyuser.hue.groups=*
 
 services:
+  postgres:
+    image: postgres:15-alpine
+    hostname: postgres
+    environment:
+      POSTGRES_USER: hue
+      POSTGRES_PASSWORD: hue
+      POSTGRES_DB: hue
+    healthcheck:
+      test: [ CMD-SHELL, pg_isready -U hue -d hue ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   hue:
     image: gethue/hue:latest
     platform: linux/amd64
@@ -36,6 +49,9 @@ services:
       POLARS_SKIP_CPU_CHECK: "1"
     volumes:
     - ./hue.ini:/usr/share/hue/desktop/conf/z-hue.ini
+    depends_on:
+      postgres:
+        condition: service_healthy
     networks:
     - ozone
 

--- a/static/compose/hue-ozone/docker-compose.hue-only.yaml
+++ b/static/compose/hue-ozone/docker-compose.hue-only.yaml
@@ -40,8 +40,8 @@ services:
       retries: 5
 
   hue:
-    # Pin 4.11.0: gethue/hue:latest adds Polars and segfaults under amd64 QEMU on Apple Silicon.
-    image: gethue/hue:4.11.0
+    # 4.11.0 lacks Ozone File Browser; latest segfaults on Apple Silicon QEMU.
+    image: gethue/hue:20250101-140101
     platform: linux/amd64
     hostname: hue
     ports:

--- a/static/compose/hue-ozone/docker-compose.hue-only.yaml
+++ b/static/compose/hue-ozone/docker-compose.hue-only.yaml
@@ -1,0 +1,28 @@
+# Connect Hue to an existing Ozone Docker network (HttpFS already running).
+#
+# Usage (example with knox-ozone_default network):
+#   docker network ls | grep ozone
+#   OZONE_NETWORK=knox-ozone_default docker compose -f docker-compose.hue-only.yaml up -d
+#
+# Ensure HttpFS has proxy-user settings for the Hue service user (hue):
+#   CORE-SITE.XML_httpfs.proxyuser.hue.hosts=*
+#   CORE-SITE.XML_httpfs.proxyuser.hue.groups=*
+
+services:
+  hue:
+    image: gethue/hue:latest
+    platform: linux/amd64
+    hostname: hue
+    ports:
+      - "8888:8888"
+    environment:
+      POLARS_SKIP_CPU_CHECK: "1"
+    volumes:
+      - ./hue.ini:/usr/share/hue/desktop/conf/z-hue.ini
+    networks:
+      - ozone
+
+networks:
+  ozone:
+    external: true
+    name: ${OZONE_NETWORK:-knox-ozone_default}

--- a/static/compose/hue-ozone/docker-compose.hue-only.yaml
+++ b/static/compose/hue-ozone/docker-compose.hue-only.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Connect Hue to an existing Ozone Docker network (HttpFS already running).
 #
 # Usage (example with knox-ozone_default network):
@@ -14,13 +31,13 @@ services:
     platform: linux/amd64
     hostname: hue
     ports:
-      - "8888:8888"
+    - 8888:8888
     environment:
       POLARS_SKIP_CPU_CHECK: "1"
     volumes:
-      - ./hue.ini:/usr/share/hue/desktop/conf/z-hue.ini
+    - ./hue.ini:/usr/share/hue/desktop/conf/z-hue.ini
     networks:
-      - ozone
+    - ozone
 
 networks:
   ozone:

--- a/static/compose/hue-ozone/docker-compose.hue-only.yaml
+++ b/static/compose/hue-ozone/docker-compose.hue-only.yaml
@@ -40,7 +40,8 @@ services:
       retries: 5
 
   hue:
-    image: gethue/hue:latest
+    # Pin 4.11.0: gethue/hue:latest adds Polars and segfaults under amd64 QEMU on Apple Silicon.
+    image: gethue/hue:4.11.0
     platform: linux/amd64
     hostname: hue
     ports:

--- a/static/compose/hue-ozone/docker-compose.yaml
+++ b/static/compose/hue-ozone/docker-compose.yaml
@@ -41,6 +41,8 @@ x-common-config:
   OZONE-SITE.XML_ozone.recon.address: recon:9891
   OZONE-SITE.XML_ozone.recon.db.dir: /data/metadata/recon
   OZONE-SITE.XML_ozone.replication: "1"
+  OZONE-SITE.XML_ozone.scm.block.size: 1MB
+  OZONE-SITE.XML_ozone.scm.container.size: 1GB
   OZONE-SITE.XML_ozone.scm.block.client.address: scm
   OZONE-SITE.XML_ozone.scm.client.address: scm
   OZONE-SITE.XML_ozone.scm.datanode.id.dir: /data/metadata
@@ -61,6 +63,10 @@ services:
     command: [ ozone, om ]
     environment:
       <<: *common-config
+      CORE-SITE.XML_hadoop.proxyuser.hadoop.hosts: "*"
+      CORE-SITE.XML_hadoop.proxyuser.hadoop.groups: "*"
+      CORE-SITE.XML_hadoop.proxyuser.hue.hosts: "*"
+      CORE-SITE.XML_hadoop.proxyuser.hue.groups: "*"
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       WAITFOR: scm:9876
     depends_on:
@@ -99,6 +105,8 @@ services:
     environment:
       <<: *common-config
       CORE-SITE.XML_fs.defaultFS: ofs://om
+      CORE-SITE.XML_httpfs.proxyuser.hadoop.hosts: "*"
+      CORE-SITE.XML_httpfs.proxyuser.hadoop.groups: "*"
       CORE-SITE.XML_httpfs.proxyuser.hue.hosts: "*"
       CORE-SITE.XML_httpfs.proxyuser.hue.groups: "*"
 

--- a/static/compose/hue-ozone/docker-compose.yaml
+++ b/static/compose/hue-ozone/docker-compose.yaml
@@ -1,0 +1,97 @@
+# Hue + Ozone verification stack
+#
+# Starts a non-secure Ozone cluster with HttpFS (port 14000) and Cloudera Hue (port 8888).
+# HttpFS is configured with proxy-user settings for the Hue service user.
+#
+# Usage:
+#   docker compose up -d --scale datanode=3
+#   open http://localhost:8888  (default login: admin / admin)
+#
+# Verify HttpFS before Hue:
+#   curl -i -X PUT "http://localhost:14000/webhdfs/v1/huevol?op=MKDIRS&user.name=hdfs"
+#   curl -i "http://localhost:14000/webhdfs/v1/huevol?op=LISTSTATUS&user.name=hdfs"
+
+x-image: &image
+  image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.1.1}${OZONE_IMAGE_FLAVOR:-}
+
+x-common-config: &common-config
+  OZONE-SITE.XML_hdds.datanode.dir: "/data/hdds"
+  OZONE-SITE.XML_ozone.metadata.dirs: "/data/metadata"
+  OZONE-SITE.XML_ozone.om.address: "om"
+  OZONE-SITE.XML_ozone.om.http-address: "om:9874"
+  OZONE-SITE.XML_ozone.recon.address: "recon:9891"
+  OZONE-SITE.XML_ozone.recon.db.dir: "/data/metadata/recon"
+  OZONE-SITE.XML_ozone.replication: "1"
+  OZONE-SITE.XML_ozone.scm.block.client.address: "scm"
+  OZONE-SITE.XML_ozone.scm.client.address: "scm"
+  OZONE-SITE.XML_ozone.scm.datanode.id.dir: "/data/metadata"
+  OZONE-SITE.XML_ozone.scm.names: "scm"
+  no_proxy: "om,recon,scm,s3g,httpfs,hue,localhost,127.0.0.1"
+
+services:
+  datanode:
+    <<: *image
+    command: ["ozone", "datanode"]
+    environment:
+      <<: *common-config
+
+  om:
+    <<: *image
+    ports:
+      - "9874:9874"
+    command: ["ozone", "om"]
+    environment:
+      <<: *common-config
+      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      WAITFOR: scm:9876
+    depends_on:
+      - scm
+
+  scm:
+    <<: *image
+    ports:
+      - "9876:9876"
+    command: ["ozone", "scm"]
+    environment:
+      <<: *common-config
+      ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
+
+  recon:
+    <<: *image
+    ports:
+      - "9888:9888"
+    command: ["ozone", "recon"]
+    environment:
+      <<: *common-config
+
+  s3g:
+    <<: *image
+    ports:
+      - "9878:9878"
+    command: ["ozone", "s3g"]
+    environment:
+      <<: *common-config
+
+  httpfs:
+    <<: *image
+    ports:
+      - "14000:14000"
+    command: ["ozone", "httpfs"]
+    environment:
+      <<: *common-config
+      CORE-SITE.XML_fs.defaultFS: "ofs://om"
+      CORE-SITE.XML_httpfs.proxyuser.hue.hosts: "*"
+      CORE-SITE.XML_httpfs.proxyuser.hue.groups: "*"
+
+  hue:
+    image: gethue/hue:latest
+    platform: linux/amd64
+    hostname: hue
+    ports:
+      - "8888:8888"
+    environment:
+      POLARS_SKIP_CPU_CHECK: "1"
+    volumes:
+      - ./hue.ini:/usr/share/hue/desktop/conf/z-hue.ini
+    depends_on:
+      - httpfs

--- a/static/compose/hue-ozone/docker-compose.yaml
+++ b/static/compose/hue-ozone/docker-compose.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Hue + Ozone verification stack
 #
 # Starts a non-secure Ozone cluster with HttpFS (port 14000) and Cloudera Hue (port 8888).
@@ -11,47 +28,49 @@
 #   curl -i -X PUT "http://localhost:14000/webhdfs/v1/huevol?op=MKDIRS&user.name=hdfs"
 #   curl -i "http://localhost:14000/webhdfs/v1/huevol?op=LISTSTATUS&user.name=hdfs"
 
-x-image: &image
+x-image:
+  &image
   image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.1.1}${OZONE_IMAGE_FLAVOR:-}
 
-x-common-config: &common-config
-  OZONE-SITE.XML_hdds.datanode.dir: "/data/hdds"
-  OZONE-SITE.XML_ozone.metadata.dirs: "/data/metadata"
-  OZONE-SITE.XML_ozone.om.address: "om"
-  OZONE-SITE.XML_ozone.om.http-address: "om:9874"
-  OZONE-SITE.XML_ozone.recon.address: "recon:9891"
-  OZONE-SITE.XML_ozone.recon.db.dir: "/data/metadata/recon"
+x-common-config:
+  &common-config
+  OZONE-SITE.XML_hdds.datanode.dir: /data/hdds
+  OZONE-SITE.XML_ozone.metadata.dirs: /data/metadata
+  OZONE-SITE.XML_ozone.om.address: om
+  OZONE-SITE.XML_ozone.om.http-address: om:9874
+  OZONE-SITE.XML_ozone.recon.address: recon:9891
+  OZONE-SITE.XML_ozone.recon.db.dir: /data/metadata/recon
   OZONE-SITE.XML_ozone.replication: "1"
-  OZONE-SITE.XML_ozone.scm.block.client.address: "scm"
-  OZONE-SITE.XML_ozone.scm.client.address: "scm"
-  OZONE-SITE.XML_ozone.scm.datanode.id.dir: "/data/metadata"
-  OZONE-SITE.XML_ozone.scm.names: "scm"
-  no_proxy: "om,recon,scm,s3g,httpfs,hue,localhost,127.0.0.1"
+  OZONE-SITE.XML_ozone.scm.block.client.address: scm
+  OZONE-SITE.XML_ozone.scm.client.address: scm
+  OZONE-SITE.XML_ozone.scm.datanode.id.dir: /data/metadata
+  OZONE-SITE.XML_ozone.scm.names: scm
+  no_proxy: om,recon,scm,s3g,httpfs,hue,localhost,127.0.0.1
 
 services:
   datanode:
     <<: *image
-    command: ["ozone", "datanode"]
+    command: [ ozone, datanode ]
     environment:
       <<: *common-config
 
   om:
     <<: *image
     ports:
-      - "9874:9874"
-    command: ["ozone", "om"]
+    - 9874:9874
+    command: [ ozone, om ]
     environment:
       <<: *common-config
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       WAITFOR: scm:9876
     depends_on:
-      - scm
+    - scm
 
   scm:
     <<: *image
     ports:
-      - "9876:9876"
-    command: ["ozone", "scm"]
+    - 9876:9876
+    command: [ ozone, scm ]
     environment:
       <<: *common-config
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
@@ -59,27 +78,27 @@ services:
   recon:
     <<: *image
     ports:
-      - "9888:9888"
-    command: ["ozone", "recon"]
+    - 9888:9888
+    command: [ ozone, recon ]
     environment:
       <<: *common-config
 
   s3g:
     <<: *image
     ports:
-      - "9878:9878"
-    command: ["ozone", "s3g"]
+    - 9878:9878
+    command: [ ozone, s3g ]
     environment:
       <<: *common-config
 
   httpfs:
     <<: *image
     ports:
-      - "14000:14000"
-    command: ["ozone", "httpfs"]
+    - 14000:14000
+    command: [ ozone, httpfs ]
     environment:
       <<: *common-config
-      CORE-SITE.XML_fs.defaultFS: "ofs://om"
+      CORE-SITE.XML_fs.defaultFS: ofs://om
       CORE-SITE.XML_httpfs.proxyuser.hue.hosts: "*"
       CORE-SITE.XML_httpfs.proxyuser.hue.groups: "*"
 
@@ -88,10 +107,10 @@ services:
     platform: linux/amd64
     hostname: hue
     ports:
-      - "8888:8888"
+    - 8888:8888
     environment:
       POLARS_SKIP_CPU_CHECK: "1"
     volumes:
-      - ./hue.ini:/usr/share/hue/desktop/conf/z-hue.ini
+    - ./hue.ini:/usr/share/hue/desktop/conf/z-hue.ini
     depends_on:
-      - httpfs
+    - httpfs

--- a/static/compose/hue-ozone/docker-compose.yaml
+++ b/static/compose/hue-ozone/docker-compose.yaml
@@ -106,10 +106,10 @@ services:
     environment:
       <<: *common-config
       CORE-SITE.XML_fs.defaultFS: ofs://om
-      CORE-SITE.XML_httpfs.proxyuser.hadoop.hosts: "*"
-      CORE-SITE.XML_httpfs.proxyuser.hadoop.groups: "*"
-      CORE-SITE.XML_httpfs.proxyuser.hue.hosts: "*"
-      CORE-SITE.XML_httpfs.proxyuser.hue.groups: "*"
+      HTTPFS-SITE.XML_httpfs.proxyuser.hadoop.hosts: "*"
+      HTTPFS-SITE.XML_httpfs.proxyuser.hadoop.groups: "*"
+      HTTPFS-SITE.XML_httpfs.proxyuser.hue.hosts: "*"
+      HTTPFS-SITE.XML_httpfs.proxyuser.hue.groups: "*"
 
   postgres:
     image: postgres:15-alpine

--- a/static/compose/hue-ozone/docker-compose.yaml
+++ b/static/compose/hue-ozone/docker-compose.yaml
@@ -125,7 +125,8 @@ services:
       retries: 5
 
   hue:
-    image: gethue/hue:latest
+    # Pin 4.11.0: gethue/hue:latest adds Polars and segfaults under amd64 QEMU on Apple Silicon.
+    image: gethue/hue:4.11.0
     platform: linux/amd64
     hostname: hue
     ports:

--- a/static/compose/hue-ozone/docker-compose.yaml
+++ b/static/compose/hue-ozone/docker-compose.yaml
@@ -23,11 +23,16 @@
 #
 # Usage:
 #   docker compose up -d --scale datanode=3
+#   ./init-demo-data.sh
 #   open http://localhost:8888  (default login: admin / admin)
 #
+# init-demo-data.sh creates huevol/huebucket owned by admin so the default
+# Hue login can list them at ofs://om. WebHDFS MKDIRS alone creates volumes
+# owned by the request user, which other Hue users cannot see at the root.
+#
 # Verify HttpFS before Hue:
-#   curl -i -X PUT "http://localhost:14000/webhdfs/v1/huevol?op=MKDIRS&user.name=hdfs"
-#   curl -i "http://localhost:14000/webhdfs/v1/huevol?op=LISTSTATUS&user.name=hdfs"
+#   curl -i "http://localhost:14000/webhdfs/v1/?op=LISTSTATUS&user.name=admin"
+#   curl -i "http://localhost:14000/webhdfs/v1/huevol?op=LISTSTATUS&user.name=admin"
 
 x-image:
   &image

--- a/static/compose/hue-ozone/docker-compose.yaml
+++ b/static/compose/hue-ozone/docker-compose.yaml
@@ -125,8 +125,9 @@ services:
       retries: 5
 
   hue:
-    # Pin 4.11.0: gethue/hue:latest adds Polars and segfaults under amd64 QEMU on Apple Silicon.
-    image: gethue/hue:4.11.0
+    # 4.11.0 lacks Ozone File Browser; latest segfaults on Apple Silicon QEMU.
+    # This tag has ofs_access/Ozone support without the Polars crash.
+    image: gethue/hue:20250101-140101
     platform: linux/amd64
     hostname: hue
     ports:

--- a/static/compose/hue-ozone/docker-compose.yaml
+++ b/static/compose/hue-ozone/docker-compose.yaml
@@ -17,8 +17,9 @@
 
 # Hue + Ozone verification stack
 #
-# Starts a non-secure Ozone cluster with HttpFS (port 14000) and Cloudera Hue (port 8888).
-# HttpFS is configured with proxy-user settings for the Hue service user.
+# Starts a non-secure Ozone cluster with HttpFS (port 14000), Postgres (Hue DB),
+# and Cloudera Hue (port 8888). HttpFS is configured with proxy-user settings
+# for the Hue service user.
 #
 # Usage:
 #   docker compose up -d --scale datanode=3
@@ -47,7 +48,7 @@ x-common-config:
   OZONE-SITE.XML_ozone.scm.client.address: scm
   OZONE-SITE.XML_ozone.scm.datanode.id.dir: /data/metadata
   OZONE-SITE.XML_ozone.scm.names: scm
-  no_proxy: om,recon,scm,s3g,httpfs,hue,localhost,127.0.0.1
+  no_proxy: om,recon,scm,s3g,httpfs,hue,postgres,localhost,127.0.0.1
 
 services:
   datanode:
@@ -110,6 +111,19 @@ services:
       CORE-SITE.XML_httpfs.proxyuser.hue.hosts: "*"
       CORE-SITE.XML_httpfs.proxyuser.hue.groups: "*"
 
+  postgres:
+    image: postgres:15-alpine
+    hostname: postgres
+    environment:
+      POSTGRES_USER: hue
+      POSTGRES_PASSWORD: hue
+      POSTGRES_DB: hue
+    healthcheck:
+      test: [ CMD-SHELL, pg_isready -U hue -d hue ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   hue:
     image: gethue/hue:latest
     platform: linux/amd64
@@ -121,4 +135,7 @@ services:
     volumes:
     - ./hue.ini:/usr/share/hue/desktop/conf/z-hue.ini
     depends_on:
-    - httpfs
+      postgres:
+        condition: service_healthy
+      httpfs:
+        condition: service_started

--- a/static/compose/hue-ozone/hue.ini
+++ b/static/compose/hue-ozone/hue.ini
@@ -31,3 +31,14 @@ name=hue
 [[[default]]]
 fs_defaultfs=ofs://om
 webhdfs_url=http://httpfs:14000/webhdfs/v1
+nice_name=Ozone
+
+[hadoop]
+# Ozone-only stack: disable default HDFS File Browser (localhost:50070).
+[[hdfs_clusters]]
+[[[default]]]
+is_enabled=false
+
+[[yarn_clusters]]
+[[[default]]]
+is_enabled=false

--- a/static/compose/hue-ozone/hue.ini
+++ b/static/compose/hue-ozone/hue.ini
@@ -1,0 +1,8 @@
+[desktop]
+secret_key=hue-ozone-dev-secret-key
+enable_chunked_file_uploader=false
+
+[[ozone]]
+[[[default]]]
+fs_defaultfs=ofs://om
+webhdfs_url=http://httpfs:14000/webhdfs/v1

--- a/static/compose/hue-ozone/hue.ini
+++ b/static/compose/hue-ozone/hue.ini
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [desktop]
 secret_key=hue-ozone-dev-secret-key
 enable_chunked_file_uploader=false

--- a/static/compose/hue-ozone/hue.ini
+++ b/static/compose/hue-ozone/hue.ini
@@ -19,6 +19,14 @@
 secret_key=hue-ozone-dev-secret-key
 enable_chunked_file_uploader=false
 
+[[database]]
+engine=postgresql_psycopg2
+host=postgres
+port=5432
+user=hue
+password=hue
+name=hue
+
 [[ozone]]
 [[[default]]]
 fs_defaultfs=ofs://om

--- a/static/compose/hue-ozone/init-demo-data.sh
+++ b/static/compose/hue-ozone/init-demo-data.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+OM_HOST="${OM_HOST:-om}"
+VOLUME="${DEMO_VOLUME:-huevol}"
+BUCKET="${DEMO_BUCKET:-huebucket}"
+OWNER="${DEMO_OWNER:-admin}"
+
+exec_om() {
+  docker compose exec -T "$OM_HOST" "$@"
+}
+
+wait_for_om() {
+  exec_om ozone admin safemode wait
+}
+
+recreate_demo_paths() {
+  exec_om ozone sh bucket delete "/${VOLUME}/${BUCKET}" 2>/dev/null || true
+  exec_om ozone sh volume delete "/${VOLUME}" 2>/dev/null || true
+  exec_om ozone sh volume create "/${VOLUME}" -u "${OWNER}"
+  exec_om ozone sh bucket create "/${VOLUME}/${BUCKET}" --layout fso
+}
+
+wait_for_om
+recreate_demo_paths
+echo "Demo Ozone paths ready for Hue user '${OWNER}': /${VOLUME}/${BUCKET}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds a Hue integration guide and a local Docker Compose verification stack for browsing Ozone through HttpFS.

### Documentation (`docs/04-user-guide/02-integrations/02-hue.md`)

- Architecture, prerequisites, HttpFS proxy-user setup, and `hue.ini` Ozone configuration
- Hue user permissions (`filebrowser.ofs_access`)
- Limitations, bucket layout guidance, and troubleshooting (HDFS vs Ozone File Browser, impersonation, empty `ofs://om`, WebHDFS errors)

### Verification stack (`static/compose/hue-ozone/`)

- All-in-one Ozone + HttpFS + Postgres (HueDB) + Hue compose files
- `hue.ini` with Postgres `[[database]]`, Ozone `[[ozone]]`, and HDFS/YARN disabled for an Ozone-only stack
- `init-demo-data.sh` seeds `huevol` / `huevol/huebucket` (FSO) owned by `admin` for the default Hue login
- Hue image pinned to `gethue/hue:20250101-140101` (Ozone File Browser support; avoids `latest` Polars segfault on Apple Silicon QEMU)
- HttpFS proxy-user settings via `HTTPFS-SITE.XML_httpfs.proxyuser.*` env vars (must land in `httpfs-site.xml`)

### Review feedback addressed

- [Harshg999 review](https://github.com/apache/ozone-site/pull/203#pullrequestreview-4704996505): added Postgres HueDB to the minimal compose stack

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-14082

## How was this patch tested?

```bash
cd static/compose/hue-ozone
docker compose up -d --scale datanode=3
./init-demo-data.sh
```

Verified locally:

- Postgres healthy; Hue DB migrations complete
- HttpFS WebHDFS `LISTSTATUS` on `huevol` / `huebucket` as `admin`
- Hue UI at http://localhost:8888 (`admin` / `admin`)
- Ozone File Browser at `ofs://om` shows `huevol` → `huebucket` (empty bucket is expected; no sample files are seeded)
- HttpFS Hue impersonation works with `httpfs.proxyuser.hue` in `httpfs-site.xml`
- `pnpm run lint` and `pnpm run build`

Manual UI checks in Chrome: Hue login, **Ozone** sidebar (not HDFS **Files**), browse volume and bucket paths.

- [x] The CI checks on my fork are passing
- [x] I verified the rendered content using a local preview
- [x] I manually verified the steps provided in this change work as described