### PR TITLE
HDDS-14658. [Docs] Show all available versions in the drop-down menu and defaults to Next.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -245,7 +245,13 @@ const config = {
           exclude: [
             '**/06-troubleshooting/**',
             '**/07-system-internals/**',
-          ]
+          ],
+          versions: {
+            current: {
+              label: 'Next',
+              banner: 'unreleased',
+            },
+          },
         },
         blog: {
           showReadingTime: true,
@@ -324,24 +330,9 @@ const config = {
         },
         items: [
           {
-            label: 'Docs',
-            position: 'left',
-            items: [
-              {
-                label: 'Latest Docs',
-                to: 'docs',
-              },
-              {
-                label: 'Docs 2.0.0 (Archived)',
-                href: '/docs/2.0.0/',
-		target: '_blank'
-              },
-              {
-                label: 'Docs 1.4.1 (Archived)',
-                href: '/docs/1.4.1/',
-		target: '_blank'
-              },
-            ],
+            label: 'Docs', // 'User documentation' link
+            to: 'docs/next',    // Links to the 'Next' version
+            position: 'left', // Keep it on the left
           },
           {
             to: 'download',
@@ -395,6 +386,26 @@ const config = {
           //   type: 'localeDropdown',
           //   position: 'right',
           // },
+          {
+            type: 'docsVersionDropdown', // User doc version select on the right
+            position: 'right',
+            dropdownItemsAfter: [
+              {
+                type: 'html',
+                value: '<hr class="dropdown-separator">',
+              },
+              {
+                label: 'Docs 2.0.0 (Archived)',
+                href: '/docs/2.0.0/',
+                target: '_blank',
+              },
+              {
+                label: 'Docs 1.4.1 (Archived)',
+                href: '/docs/1.4.1/',
+                target: '_blank',
+              },
+            ],
+          },
           {
             href: 'https://github.com/apache/ozone',
             position: 'right',


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-14658. [Docs] Show all available versions in the drop-down menu and defaults to Next.

Please describe your PR in detail:
- The Docs menu points to the Next version.
- Moved document version drop down menu to the right.
- Use the docsVersionDropdown macro to automatically populate available versions.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-14658

## How was this patch tested?

1. CI passed.
2. screenshot
<img width="1552" height="273" alt="Screenshot 2026-02-18 at 11 00 03 PM" src="https://github.com/user-attachments/assets/c8918207-c570-4e82-973f-727fdde91d98" />

