### PR TITLE
HDDS-12321. Add Trino integration user guide

### DIFF
--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -1,8 +1,198 @@
 ---
-draft: true
+sidebar_label: Trino
 ---
 
-# Trino
+# Trino with Ozone (Hive connector) and Ranger
 
-**TODO:** File a subtask under [HDDS-9858](https://issues.apache.org/jira/browse/HDDS-9858) and complete this page or section.
-**TODO:** Uncomment link to this page in src/pages/index.js
+[Trino](https://trino.io/) can query tables whose data lives in Apache Ozone when you use the **Hive connector** and a **Hive Metastore (HMS)** that already understands Ozone paths (`ofs://`, `o3fs://`, or `s3a://`, depending on how tables were created). [Apache Ranger](https://ranger.apache.org/) can enforce access control for Trino through Trino’s Ranger integration.
+
+This page describes a **Docker-based lab-style setup**: build the standard Ozone **Hadoop 3 filesystem** JAR (`ozonefs-hadoop3` / `ozone-filesystem-hadoop3-*.jar`), join Trino to the same Docker network as Ozone, Ranger, Hadoop, and Hive, then configure a Hive catalog and Ranger access control.
+
+:::note
+This is an **advanced** integration. Names (`ranger-hive`, `rangernw`), compose file names, and paths come from typical Ranger `dev-support/ranger-docker` layouts and **will differ** if you change compose projects or image tags. Treat hostnames and file names as examples and align them with your environment.
+:::
+
+For how Hive uses Ozone (warehouse paths, `ofs://` URIs, and the filesystem JAR), see the [Hive](./hive) integration page.
+
+## Prerequisites
+
+- Docker and Docker Compose, with enough memory for Ranger, Hive, Ozone, and Trino.
+- Source tree for **Apache Ozone** and a JDK / Maven build able to run `mvn package` for the **`ozonefs-hadoop3`** module (or a release download of `ozone-filesystem-hadoop3`).
+- A running **Hive Metastore** that Trino can reach on `thrift://<host>:9083`.
+- **Hadoop `core-site.xml`** (and related config) that defines the Ozone filesystem implementation and service addresses, mounted or copied into the Trino container where `hive.config.resources` points.
+- If you use Ranger: Trino **Ranger plugin** configuration files (`ranger-trino-security.xml`, `ranger-trino-audit.xml`, `ranger-policymgr-ssl.xml`, and policies synced from Ranger Admin). See the [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html) documentation.
+
+## Ozone JAR and Trino
+
+Trino bundles its own Hadoop libraries. For the Hive connector to read and write `ofs://` / `o3fs://` paths, the **`ozone-filesystem-hadoop3-*.jar`** from the **`ozonefs-hadoop3`** Maven module must be on the Hive plugin classpath (see below).
+
+The older **`ozonefs-hadoop3-client`** artifact and the **`proto.shaded.prefix`** Maven option are **no longer used** in current Ozone; build or download the standard **`ozonefs-hadoop3`** output only.
+
+:::warning
+Pair **Ozone and Trino releases** that agree on a compatible Hadoop 3.x line. If Trino fails to load the Ozone filesystem or you see class or protobuf conflicts, align versions or ask on the Ozone dev list.
+:::
+
+## 1. Build the Ozone filesystem JAR
+
+From your Ozone source checkout, build the Hadoop 3 filesystem module (and its dependencies):
+
+```bash
+mvn clean package -DskipTests -pl hadoop-ozone/ozonefs-hadoop3 -am
+```
+
+When the build succeeds, copy the artifact from the module output directory:
+
+```bash
+cd hadoop-ozone/ozonefs-hadoop3/target/
+cp ozone-filesystem-hadoop3-*.jar /tmp/
+```
+
+The version in the file name (`*-SNAPSHOT.jar` or a release version) **depends on your Ozone branch**. You can also use the same artifact from Maven Central (coordinates `org.apache.ozone:ozone-filesystem-hadoop3`) at the version that matches your cluster instead of building from source.
+
+:::note Historical note
+An older lab used [Ozone at commit fc89ba6a](https://github.com/apache/ozone/tree/fc89ba6aef9bd01562f76ef19888a56950bc6939); layout and Maven modules have changed since then. Prefer a **maintained release tag** that matches your cluster.
+:::
+
+## 2. Bring up Ozone, Ranger, Hive, and Hadoop in Docker
+
+### Option A: Ranger project compose stacks (recommended for a single lab network)
+
+The Apache Ranger repo ships Docker Compose files under `dev-support/ranger-docker`.
+
+1. Clone Ranger: [https://github.com/apache/ranger](https://github.com/apache/ranger).
+2. Open `dev-support/ranger-docker` and follow the **README** there (prerequisites, passwords, profiles).
+3. Build and start the stack that includes Ranger, Hadoop, Hive, and Ozone. The README and file names on `master` **change over time**; your commands may look like the following pattern (verify against the current README):
+
+```bash
+docker compose \
+  -f docker-compose.ranger.yml \
+  -f docker-compose.ranger-hadoop.yml \
+  -f docker-compose.ranger-hive.yml \
+  -f docker-compose.ranger-ozone.yml \
+  build
+
+docker compose \
+  -f docker-compose.ranger.yml \
+  -f docker-compose.ranger-hadoop.yml \
+  -f docker-compose.ranger-hive.yml \
+  -f docker-compose.ranger-ozone.yml \
+  up -d
+```
+
+### Option B: Assemble containers yourself
+
+Alternatively, run compatible images (for example [Apache Ranger](https://hub.docker.com/r/apache/ranger), [Apache Ozone](https://hub.docker.com/r/apache/ozone), and Hive/Hadoop images you trust) and attach them to **one user-defined Docker network** so Trino can resolve HMS and Ozone by container name.
+
+:::warning Network and hostnames
+Trino’s catalog must use the **same Docker network** as HMS and the hosts named in `core-site.xml`. If Trino cannot resolve `ranger-hive` (or your HMS hostname), `thrift://` connections will fail. Replace example names with `docker network inspect` output from your stack.
+:::
+
+## 3. Run Trino and install the Ozone JAR
+
+Start a Trino container on the Ranger/Ozone network. The example uses image [trinodb/trino](https://hub.docker.com/r/trinodb/trino) and assumes the network is named `rangernw` (adjust to your setup):
+
+```bash
+docker run -d -p 8080:8080 --name trino --network rangernw trinodb/trino
+```
+
+Copy the Ozone filesystem JAR into the Hive HDFS plugin directory inside the container (paths match common Trino image layouts):
+
+```bash
+docker cp /tmp/ozone-filesystem-hadoop3-*.jar \
+  trino:/usr/lib/trino/plugin/hive/hdfs/
+```
+
+If your Trino image uses a different install root, locate `plugin/hive/hdfs` under that root.
+
+The **`ozone-filesystem-hadoop3`** module normally produces a **self-contained (shaded) JAR** meant to be dropped in as a **single** file. If you see `NoClassDefFoundError` for Ozone or gRPC classes, you may have the wrong artifact or a partial copy—use the primary `ozone-filesystem-hadoop3-*.jar` from this module’s `target/` directory, or the matching artifact from Maven Central.
+
+**Restart Trino** after adding the JAR so the plugin class loader picks it up.
+
+### Hadoop and Ozone configuration inside Trino
+
+`hive.config.resources` must point to **real files** inside the container (comma-separated list if you need more than one). Those files must define the Ozone filesystem (for example `fs.ofs.impl`) and OM/SCM addresses the same way your Hive/Hadoop stack does—usually by reusing `core-site.xml` (and sometimes additional config such as `ozone-site.xml` or keys merged into `core-site.xml`) from the Ranger/Hadoop/Ozone compose setup.
+
+The doc does **not** copy those files for you. Typical approaches:
+
+- **`docker cp`** from a Hadoop or edge container that already has the right XMLs, into a path such as `/tmp/hadoop/conf/`, or  
+- **`docker run -v`** to bind-mount a host directory of config into the Trino container.
+
+Until this matches your live Ozone cluster, Trino will fail when it tries to open `ofs://` paths even if the Hive catalog and Metastore connection work.
+
+## 4. Hive catalog properties (`hive.properties`)
+
+Create a catalog file for the Hive connector. The HMS URI and config paths **must match your deployment**.
+
+Example `hive.properties`:
+
+```properties
+connector.name=hive
+hive.metastore.uri=thrift://ranger-hive:9083
+fs.hadoop.enabled=true
+hive.config.resources=/tmp/hadoop/conf/core-site.xml
+hive.non-managed-table-writes-enabled=true
+hive.hdfs.impersonation.enabled=true
+```
+
+Copy it into the container:
+
+```bash
+docker cp hive.properties trino:/etc/trino/catalog/
+```
+
+:::warning Possible configuration gaps
+- **`hive.config.resources`**: Must list real files inside the container (often you mount a host directory of Hadoop config at `/tmp/hadoop/conf` or another path you choose).
+- **`hive.hdfs.impersonation.enabled=true`**: Requires a secure setup where Trino can impersonate end users; in minimal Docker demos this can fail if Hadoop/Ozone security is not aligned with Trino. Disable or adjust only if you understand the security trade-offs.
+- **Managed vs external tables**: Behavior depends on HMS metadata and Ozone paths; see [Hive](./hive).
+:::
+
+## 5. Ranger access control (`access-control.properties`)
+
+Ranger authorization for Trino depends on your **Trino version** and distribution: you need the Ranger access-control integration Trino expects (plugin JARs and native libraries, if any), **not** only the properties and XML files below. Follow [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html) end to end, including how to install Ranger’s Trino artifacts into the container image if required.
+
+If you enable Ranger for Trino, add an `access-control.properties` (location depends on Trino version; often `/etc/trino/`):
+
+```properties
+access-control.name=ranger
+ranger.service.name=dev_trino
+ranger.plugin.config.resource=/etc/trino/ranger-trino-security.xml,/etc/trino/ranger-trino-audit.xml,/etc/trino/ranger-policymgr-ssl.xml
+ranger.hadoop.config.resource=
+```
+
+Copy it in:
+
+```bash
+docker cp access-control.properties trino:/etc/trino/
+```
+
+You must also install the XML files referenced above (and any TLS trust stores or policy cache settings Ranger expects). Follow [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html) and your Ranger Admin deployment.
+
+:::warning Empty `ranger.hadoop.config.resource`
+The draft setup left **`ranger.hadoop.config.resource` blank**. That may be intentional for a minimal demo or it may be **incomplete** for your Ranger or Hadoop layout. Confirm with Trino and Ranger documentation whether Hadoop config must be passed to the Ranger plugin in your environment.
+:::
+
+## 6. Restart Trino and verify
+
+Restart the Trino container after configuration changes.
+
+1. Open the Trino web UI (port `8080` in the example) or use `trino-cli`.
+2. `SHOW CATALOGS` should list `hive` (or whatever you named the properties file without `.properties`).
+3. Run a simple query against a table you know is stored on Ozone (path visible in HMS).
+
+If initialization fails, check Trino logs for:
+
+- Class loading or **protobuf** errors (often an Ozone / Hadoop / Trino **version mismatch** or a wrong JAR on the plugin classpath).
+- **Metastore** connection errors (wrong host, port, or network).
+- **Filesystem** errors (missing `core-site.xml` properties for `ofs` / `o3fs`).
+
+## Summary of risks and open checks
+
+| Area | What to verify |
+| ---- | -------------- |
+| Ozone JAR vs Trino | Use **`ozone-filesystem-hadoop3-*.jar`** from **`ozonefs-hadoop3`**; Ozone version and Hadoop line must match Trino and your cluster. |
+| Versions | Pinned Git commits and `*-SNAPSHOT` JARs are for **development**, not production baselines. |
+| Docker compose | File names and services come from the Ranger repo; they **drift** on `master`. |
+| Ranger | All `ranger-*.xml` files, service definitions, and `ranger.hadoop.config.resource` must match Ranger Admin and your Hadoop/Ozone config. |
+| Impersonation | `hive.hdfs.impersonation.enabled` requires a coherent security story across Trino, Hadoop, and Ozone. |
+
+For work tracked around this integration on the Ozone side, see [HDDS-12321](https://issues.apache.org/jira/browse/HDDS-12321).

--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -205,20 +205,20 @@ Use the **`ozone`** catalog ( **`ofs://`** ) for the steps below. Do **not** run
 SHOW CATALOGS;
 SHOW SCHEMAS FROM ozone;
 
-CREATE SCHEMA ozone.lab WITH (location = 'ofs://om/s3v/trino-lab/lab');
+CREATE SCHEMA ozone.ofslab WITH (location = 'ofs://om/s3v/trino-lab/ofslab');
 
-CREATE TABLE ozone.lab.demo (
+CREATE TABLE ozone.ofslab.demo (
   id bigint,
   name varchar
 ) WITH (format = 'PARQUET');
 
-INSERT INTO ozone.lab.demo VALUES (1, 'alice'), (2, 'bob');
+INSERT INTO ozone.ofslab.demo VALUES (1, 'alice'), (2, 'bob');
 
-SELECT * FROM ozone.lab.demo ORDER BY id;
+SELECT * FROM ozone.ofslab.demo ORDER BY id;
 ```
 
 :::note One HMS, two catalogs
-If you add the optional **`ozone_s3a`** catalog later, it shares the same Hive Metastore. Schema and table names must not collide, and each schema's `location` must match the catalog you query (`ofs://…` for **`ozone`**, `s3a://…` for **`ozone_s3a`**). If you already created `lab` with an `s3a://` location while testing S3, create a new schema (for example `ofslab`) on the **`ozone`** catalog instead of reusing `lab`.
+The optional **`ozone_s3a`** catalog uses the same Hive Metastore. Use **different schema names** for each path (`ofslab` above vs `lab` in the S3 section) so locations do not collide. Query each table through the catalog that matches its location: **`ofs://…`** → **`ozone`**, **`s3a://…`** → **`ozone_s3a`**. Using **`ozone.lab.demo`** after creating `lab` via S3 fails with `ClassNotFoundException: S3AFileSystem` because that table's location is `s3a://…`.
 :::
 
 ## Alternative: Ozone S3 Gateway (`s3a://`)
@@ -338,7 +338,7 @@ Use **`ofs://`** (above) when you need verified writes from Trino. Re-test the S
 | Symptom | Likely cause |
 | ------- | ------------ |
 | `NoClassDefFoundError: LeaseRecoverable` | Trino Hadoop **3.3** vs Ozone **3.4** interfaces; build and copy `hadoop34-interfaces.jar` (step 1) or upgrade Trino. |
-| `ClassNotFoundException: S3AFileSystem` on **`ozone`** writes | `fs.s3a.*` in Trino's `core-site.xml`, or querying a table whose HMS location is `s3a://…` through the **`ozone`** catalog. Use ofs-only XML in Trino and `ofs://` schema/table locations. |
+| `ClassNotFoundException: S3AFileSystem` on **`ozone`** reads/writes | Table or schema location is `s3a://…` but you queried the **`ozone`** catalog, or `fs.s3a.*` is in Trino's `core-site.xml`. Use **`ozone_s3a`** for `s3a://` tables, **`ozone`** + `ofs://` locations for native Ozone, and ofs-only XML in Trino. |
 | `UnsupportedFileSystemException: ofs` | Missing or wrong `hive.config.resources`, or HMS missing Ozone JAR/XML. |
 | INSERT fails moving staged files | Staging path not set to a **`RATIS/ONE`** bucket. |
 | Writes hang | SCM safe mode; not enough healthy Datanodes or disk for pipelines. |

--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -76,7 +76,7 @@ docker compose -p ozone-trino exec scm ozone admin safemode exit
 ```
 
 :::note Docker lab sizing
-Three Datanodes avoid replication and pipeline issues on a small compose stack. If Docker disk space is tight, set smaller SCM container defaults in compose (for example `ozone.scm.container.size: "1GB"`).
+Three Datanodes are **required** for the verified **`INSERT`** path: Trino staging blocks still use **`RATIS/THREE`** in this lab, and a single Datanode cannot satisfy that pipeline. If Docker disk space is tight, set smaller SCM container defaults in compose (for example `ozone.scm.container.size: "1GB"`) rather than scaling Datanodes below three.
 :::
 
 ## 3. Prepare Hadoop XML
@@ -141,19 +141,13 @@ Use the **`ofs`-only** `core-site.xml` above inside the Trino container for the 
 
 ## 4. Start Hive Metastore and Trino
 
-Start HMS on the **same Docker network** as Ozone (example network: `ozone-trino_default`). Mount the Ozone JAR plus the XML files:
+Prepare a host directory for lab files (example **`/tmp/trino-lab/`**) with:
 
-```bash
-docker run -d --name hive-metastore \
-  --network ozone-trino_default \
-  -p 9083:9083 \
-  -e SERVICE_NAME=metastore \
-  -v /path/to/hive-conf:/opt/hive/conf:ro \
-  -v /tmp/ozone-filesystem-hadoop3-2.2.0.jar:/opt/hive/lib/ozone-filesystem-hadoop3.jar:ro \
-  apache/hive:4.0.1
-```
+- **`hive-conf/`** — `core-site.xml`, `ozone-site.xml`, `hive-site.xml` for HMS
+- **`hadoop-conf/`** — **`ofs`-only** `core-site.xml` and `ozone-site.xml` for Trino (step 3)
+- **`ozone.properties`** — Trino catalog file (contents below)
 
-Include **`core-site.xml`**, **`ozone-site.xml`**, and **`hive-site.xml`** in `hive-conf`. Example **`hive-site.xml`** (embedded Derby is fine for the lab):
+Example **`hive-site.xml`** (embedded Derby is fine for the lab):
 
 ```xml
 <?xml version="1.0"?>
@@ -179,30 +173,45 @@ Include **`core-site.xml`**, **`ozone-site.xml`**, and **`hive-site.xml`** in `h
 
 For HMS, you can merge **`ofs`** and **`fs.s3a.*`** properties into one `core-site.xml` under `hive-conf/` when running both paths. Keep Trino's copy **`ofs`-only** (see step 3).
 
-Start Trino on the same network and mount the Hadoop XML directory:
+Start HMS on the **same Docker network** as Ozone (example network: `ozone-trino_default`), copy configuration and the Ozone JAR in, then restart:
+
+```bash
+docker run -d --name hive-metastore \
+  --network ozone-trino_default \
+  -p 9083:9083 \
+  -e SERVICE_NAME=metastore \
+  apache/hive:4.0.1
+
+docker cp /tmp/trino-lab/hive-conf/core-site.xml hive-metastore:/opt/hive/conf/
+docker cp /tmp/trino-lab/hive-conf/ozone-site.xml hive-metastore:/opt/hive/conf/
+docker cp /tmp/trino-lab/hive-conf/hive-site.xml hive-metastore:/opt/hive/conf/
+docker cp /tmp/ozone-filesystem-hadoop3-2.2.0.jar \
+  hive-metastore:/opt/hive/lib/ozone-filesystem-hadoop3.jar
+docker restart hive-metastore
+```
+
+Start Trino on the same network, copy Hadoop XML, JARs, and the catalog file in, then restart:
 
 ```bash
 docker run -d --name trino \
   --network ozone-trino_default \
   -p 8080:8080 \
-  --memory=1536m \
-  -e JAVA_TOOL_OPTIONS="-Xmx768m -XX:+UseSerialGC" \
-  -v /path/to/hadoop-conf:/tmp/hadoop/conf:ro \
+  --memory=2g \
+  -e JAVA_TOOL_OPTIONS="-Xmx1024m -XX:+UseSerialGC" \
   trinodb/trino
-```
 
-Copy the Ozone JAR, the Hadoop 3.4 interface stub (Trino 483), and the catalog property file into Trino, then restart:
-
-```bash
+docker exec trino mkdir -p /tmp/hadoop/conf
+docker cp /tmp/trino-lab/hadoop-conf/core-site.xml trino:/tmp/hadoop/conf/
+docker cp /tmp/trino-lab/hadoop-conf/ozone-site.xml trino:/tmp/hadoop/conf/
 docker cp /tmp/ozone-filesystem-hadoop3-2.2.0.jar \
   trino:/usr/lib/trino/plugin/hive/hdfs/
 docker cp /tmp/hadoop34-interfaces.jar \
   trino:/usr/lib/trino/plugin/hive/hdfs/
-docker cp /path/to/ozone.properties trino:/etc/trino/catalog/ozone.properties
+docker cp /tmp/trino-lab/ozone.properties trino:/etc/trino/catalog/ozone.properties
 docker restart trino
 ```
 
-Create **`ozone.properties`** on the host (path in the `docker cp` command above):
+**`ozone.properties`** (the file name becomes the catalog name):
 
 ```properties
 connector.name=hive
@@ -215,15 +224,15 @@ hive.dfs.replication=1
 hive.temporary-staging-directory-path=ofs://om/s3v/trino-lab/.staging
 ```
 
-Set **`hive.temporary-staging-directory-path`** to your **`RATIS/ONE`** bucket. Trino otherwise stages under an auto-created `tmp` volume with default **`RATIS/THREE`**, which breaks moves into a one-replica lab bucket.
+Set **`hive.temporary-staging-directory-path`** to your **`RATIS/ONE`** bucket. Trino otherwise stages under an auto-created `tmp` volume with default **`RATIS/THREE`**, which fails when the compose stack has fewer than three healthy Datanodes.
 
 :::tip Docker Desktop on macOS
-Use **`docker cp`** for catalog files and JARs. Bind-mount a directory for config, not a single file under `/tmp` (mounts can appear empty in the container).
+Bind mounts into these containers often appear **empty** (including `-v .../hive-conf:/opt/hive/conf`). Use the **`docker cp`** workflow above for HMS and Trino configuration and JARs. Run SQL from the Trino Web UI at `http://localhost:8080` or with a host-installed Trino CLI—avoid `docker exec trino trino ...` on memory-constrained hosts, because it starts a second JVM inside the container.
 :::
 
 ## 5. Verify
 
-Use the **`ozone`** catalog and **`ofs://`** for the steps below. Do **not** run these writes on **`ozone_s3a`**—S3 Gateway inserts fail in this lab (see [Troubleshooting](#troubleshooting)).
+Use the **`ozone`** catalog and **`ofs://`** for the steps below. Do **not** run these writes on **`ozone_s3a`**—S3 Gateway inserts fail in this lab (see [Troubleshooting](#troubleshooting)). Open the Trino Web UI at `http://localhost:8080` and run the SQL there (or use a host-installed Trino CLI).
 
 ```sql
 SHOW CATALOGS;
@@ -302,7 +311,14 @@ Add S3A client settings to **`core-site.xml`** (insecure lab example; adjust hos
 
 #### HMS S3A JARs
 
-Mount **`hadoop-aws-3.3.5.jar`** (match Trino's Hadoop **3.3.x** line) plus its AWS SDK v1 dependencies on **HMS** classpath—for example `aws-java-sdk-core`, `aws-java-sdk-s3`, `aws-java-sdk-dynamodb`, `joda-time`, and Jackson JARs at the same SDK version.
+Copy **`hadoop-aws-3.3.5.jar`** (match Trino's Hadoop **3.3.x** line) plus its AWS SDK v1 dependencies into HMS with **`docker cp`**, then restart HMS—for example `aws-java-sdk-core`, `aws-java-sdk-s3`, `aws-java-sdk-dynamodb`, `joda-time`, and Jackson JARs at the same SDK version:
+
+```bash
+docker cp /path/to/hadoop-aws-3.3.5.jar hive-metastore:/opt/hive/lib/hadoop-aws.jar
+docker cp /path/to/aws-java-sdk-core.jar hive-metastore:/opt/hive/lib/
+# ... other S3A dependency JARs ...
+docker restart hive-metastore
+```
 
 ### Trino catalog for S3
 
@@ -372,8 +388,8 @@ Use **`ofs://`** (above) when you need verified writes from Trino. Re-test the S
 | ------- | ------------ |
 | `NoClassDefFoundError: LeaseRecoverable` | Trino Hadoop **3.3** vs Ozone **3.4** interfaces; build and copy `hadoop34-interfaces.jar` (step 1) or upgrade Trino. |
 | `ClassNotFoundException: S3AFileSystem` on **`ozone`** reads/writes | Table or schema location is `s3a://…` but you queried the **`ozone`** catalog, or `fs.s3a.*` is in Trino's `core-site.xml`. Use **`ozone_s3a`** for `s3a://` tables, **`ozone`** + `ofs://` locations for native Ozone, and ofs-only XML in Trino. |
-| `UnsupportedFileSystemException: ofs` | Missing or wrong `hive.config.resources`, or HMS missing Ozone JAR/XML. |
-| INSERT fails moving staged files | Staging path not set to a **`RATIS/ONE`** bucket. |
+| `UnsupportedFileSystemException: ofs` | HMS missing Ozone JAR/XML (often empty bind mounts on Docker Desktop—use **`docker cp`** and restart HMS), or Trino `hive.config.resources` paths wrong. |
+| INSERT fails moving staged files / `RATIS/THREE` pipeline error | Staging path not set to the lab bucket, or fewer than **three** healthy Datanodes for default **`RATIS/THREE`** staging blocks. |
 | Writes hang | SCM safe mode; not enough healthy Datanodes or disk for pipelines. |
 | Metastore connection errors | Trino not on the same Docker network as HMS, or wrong hostname in `hive.metastore.uri`. |
 | S3 `CREATE SCHEMA` fails on HMS | HMS missing S3A JARs or `fs.s3a.*` settings in `core-site.xml`; use `s3a://` locations. |

--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -4,9 +4,9 @@ sidebar_label: Trino
 
 # Trino with Ozone
 
-[Trino](https://trino.io/) reads and writes Ozone data through the **Hive connector** and a **Hive Metastore (HMS)** that understands `ofs://` paths. For background on Hive warehouse paths and the Ozone filesystem JAR, see [Hive](./01-hive).
+[Trino](https://trino.io/) reads and writes Ozone data through the **Hive connector** and a **Hive Metastore (HMS)**. The recommended path uses native Ozone **`ofs://`** URIs; an alternative uses Ozone's **S3 Gateway** with **`s3a://`** / **`s3://`** URIs. For background on Hive warehouse paths and the Ozone filesystem JAR, see [Hive](./01-hive).
 
-This page walks through a **Docker lab** verified with **Ozone 2.2.0**, **`ozone-filesystem-hadoop3-2.2.0.jar`**, and **`trinodb/trino:483`**.
+This page walks through a **Docker lab** verified with **Ozone 2.2.0** and **`trinodb/trino:483`**. The **`ofs://`** flow (including **`INSERT` / `SELECT`**) was verified end-to-end; the **S3 Gateway** flow was verified for creating schemas/tables and reads, but not writes (see [Alternative: Ozone S3 Gateway](#alternative-ozone-s3-gateway-s3a)).
 
 ## What you need
 
@@ -211,6 +211,114 @@ INSERT INTO ozone.lab.demo VALUES (1, 'alice'), (2, 'bob');
 SELECT * FROM ozone.lab.demo ORDER BY id;
 ```
 
+## Alternative: Ozone S3 Gateway (`s3a://`)
+
+Use this when you prefer the Hadoop **S3A** bucket layout (`s3a://bucket/path`) or Ozone's **S3 Gateway** (`s3g`) instead of the Ozone filesystem JAR on Trino. See also [s3a and Ozone](../01-client-interfaces/04-s3a).
+
+:::note Trino 483 uses native S3, not Hadoop S3A JARs
+Trino **483** removed legacy `hive.s3.*` settings. Configure **`fs.s3.enabled=true`** and **`s3.*`** catalog properties instead. Do **not** add `hadoop-aws` to Trino's classpath—HMS still needs the Hadoop S3A client to validate `s3a://` paths when creating schemas and tables.
+:::
+
+### Extra setup
+
+#### Start S3 Gateway
+
+Ensure the **S3 Gateway** service is running (included in [Apache Ozone Docker](https://github.com/apache/ozone-docker); service name **`s3g`**, port **9878**).
+
+#### HMS `core-site.xml` S3A settings
+
+Add S3A client settings to **`core-site.xml`** (insecure lab example; adjust hostnames and keys for production):
+
+```xml
+  <property>
+    <name>fs.s3a.impl</name>
+    <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+  </property>
+  <property>
+    <name>fs.s3a.endpoint</name>
+    <value>http://s3g:9878</value>
+  </property>
+  <property>
+    <name>fs.s3a.endpoint.region</name>
+    <value>us-east-1</value>
+  </property>
+  <property>
+    <name>fs.s3a.path.style.access</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>fs.s3a.bucket.probe</name>
+    <value>0</value>
+  </property>
+  <property>
+    <name>fs.s3a.change.detection.mode</name>
+    <value>none</value>
+  </property>
+  <property>
+    <name>fs.s3a.access.key</name>
+    <value>test</value>
+  </property>
+  <property>
+    <name>fs.s3a.secret.key</name>
+    <value>test</value>
+  </property>
+```
+
+#### HMS S3A JARs
+
+Mount **`hadoop-aws-3.3.5.jar`** (match Trino's Hadoop **3.3.x** line) plus its AWS SDK v1 dependencies on **HMS** classpath—for example `aws-java-sdk-core`, `aws-java-sdk-s3`, `aws-java-sdk-dynamodb`, `joda-time`, and Jackson JARs at the same SDK version.
+
+### Trino catalog for S3
+
+Create a separate catalog file (example **`ozone_s3a.properties`**):
+
+```properties
+connector.name=hive
+hive.metastore.uri=thrift://hive-metastore:9083
+fs.s3.enabled=true
+s3.endpoint=http://s3g:9878
+s3.region=us-east-1
+s3.path-style-access=true
+s3.aws-access-key=test
+s3.aws-secret-key=test
+hive.non-managed-table-writes-enabled=true
+```
+
+Use **`s3a://`** (not `s3://`) in **`CREATE SCHEMA ... WITH (location = ...)`** so HMS can create the path through its S3A client.
+
+### Verify (S3 Gateway)
+
+```sql
+CREATE SCHEMA ozone_s3a.lab WITH (location = 's3a://trino-lab/s3-lab');
+
+CREATE TABLE ozone_s3a.lab.demo (
+  id bigint,
+  name varchar
+) WITH (format = 'TEXTFILE');
+
+-- Read path: point an external table at objects already in the bucket
+CREATE TABLE ozone_s3a.readlab.demo (
+  id varchar,
+  name varchar
+)
+WITH (
+  format = 'CSV',
+  external_location = 's3a://trino-lab/s3-read'
+);
+
+SELECT * FROM ozone_s3a.readlab.demo;
+```
+
+Docker lab verification with **`fs.s3.enabled=true`** and Ozone S3G:
+
+| Step | Result |
+| ---- | ------ |
+| `CREATE SCHEMA` / `CREATE TABLE` with `s3a://` | OK |
+| `SELECT` from external data in the bucket | OK |
+| `INSERT` into managed tables | Failed (`HIVE_WRITER_CLOSE_ERROR` after long commit timeout) |
+
+Use **`ofs://`** (above) when you need verified writes from Trino. Re-test the S3 **`INSERT`** path when upgrading Trino or Ozone, or in a production-sized cluster with more memory.
+
 ## Troubleshooting
 
 | Symptom | Likely cause |
@@ -220,6 +328,8 @@ SELECT * FROM ozone.lab.demo ORDER BY id;
 | INSERT fails moving staged files | Staging path not set to a **`RATIS/ONE`** bucket. |
 | Writes hang | SCM safe mode; not enough healthy Datanodes or disk for pipelines. |
 | Metastore connection errors | Trino not on the same Docker network as HMS, or wrong hostname in `hive.metastore.uri`. |
+| S3 `CREATE SCHEMA` fails on HMS | HMS missing S3A JARs or `fs.s3a.*` settings in `core-site.xml`; use `s3a://` locations. |
+| S3 `INSERT` hangs or fails on commit | Known issue in the Docker lab with Trino **483** native S3; prefer **`ofs://`** for writes. |
 
 ## Ranger (optional)
 

--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -2,48 +2,24 @@
 sidebar_label: Trino
 ---
 
-# Trino with Ozone (Hive connector) and Ranger
+# Trino with Ozone
 
-[Trino](https://trino.io/) can query tables whose data lives in Apache Ozone when you use the **Hive connector** and a **Hive Metastore (HMS)** that already understands Ozone paths (`ofs://`, `o3fs://`, or `s3a://`, depending on how tables were created). [Apache Ranger](https://ranger.apache.org/) can enforce access control for Trino through Trino’s Ranger integration.
+[Trino](https://trino.io/) reads and writes Ozone data through the **Hive connector** and a **Hive Metastore (HMS)** that understands `ofs://` paths. For background on Hive warehouse paths and the Ozone filesystem JAR, see [Hive](./01-hive).
 
-This page describes a **Docker-based lab-style setup**: obtain the standard Ozone **Hadoop 3 filesystem** JAR (`ozone-filesystem-hadoop3-*.jar`), join Trino to the same Docker network as Ozone and Hive, configure a Hive catalog, and optionally Ranger access control.
+This page walks through a **Docker lab** verified with **Ozone 2.2.0**, **`ozone-filesystem-hadoop3-2.2.0.jar`**, and **`trinodb/trino:483`**.
 
-:::note
-This is an **advanced** integration. Names (`ranger-hive`, `rangernw`), compose file names, and paths come from typical Ranger `dev-support/ranger-docker` layouts and **will differ** if you change compose projects or image tags. Treat hostnames and file names as examples and align them with your environment.
+## What you need
+
+- Docker Compose with enough memory for Ozone (three Datanodes), Hive Metastore, and Trino.
+- **`ozone-filesystem-hadoop3-*.jar`** at the **same version as your cluster** ([HDDS-14056](https://issues.apache.org/jira/browse/HDDS-14056): use this JAR only; the old **`ozone-filesystem-hadoop3-client`** artifact was removed in Ozone 2.2+).
+- HMS on `thrift://<host>:9083`, with the same Ozone JAR and Hadoop XML as Trino.
+- **`core-site.xml`** and **`ozone-site.xml`** inside the Trino container, referenced from the catalog.
+
+:::warning Trino 483 and Hadoop 3.4 interfaces
+Ozone **2.2.0** targets Hadoop **3.4** APIs. Trino **483** ships Hadoop **3.3.x**, which can cause `NoClassDefFoundError: org/apache/hadoop/fs/LeaseRecoverable` on the first `ofs://` write. For a lab, add a small supplemental JAR with the missing interface classes (`LeaseRecoverable`, `SafeMode`, `SafeModeAction`) to `plugin/hive/hdfs/` next to the Ozone JAR. Prefer a Trino release that bundles Hadoop **3.4+** when one is available for your deployment.
 :::
 
-For how Hive uses Ozone (warehouse paths, `ofs://` URIs, and the filesystem JAR), see the [Hive](./hive) integration page.
-
-## Prerequisites
-
-- Docker and Docker Compose, with enough memory for Ozone, Hive, Trino, and (optionally) Ranger.
-- The **`ozone-filesystem-hadoop3-*.jar`** artifact at the **same Ozone version as your cluster** (see [Ozone JAR and Trino](#ozone-jar-and-trino)).
-- A running **Hive Metastore** that Trino can reach on `thrift://<host>:9083`.
-- **Hadoop XML configuration** inside the Trino container that defines the Ozone filesystem (`fs.ofs.impl`, OM/SCM addresses) and is referenced by `hive.config.resources`.
-- If you use Ranger: Trino **Ranger plugin** configuration files and policies synced from Ranger Admin. See [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html).
-
-## Ozone JAR and Trino
-
-Trino bundles its own Hadoop libraries (currently Hadoop **3.3.x** in recent `trinodb/trino` images). For the Hive connector to read and write `ofs://` / `o3fs://` paths, the **`ozone-filesystem-hadoop3-*.jar`** from the **`ozonefs-hadoop3`** Maven module must be on the Hive HDFS plugin classpath (see below).
-
-Since [HDDS-14056](https://issues.apache.org/jira/browse/HDDS-14056) (Ozone 2.2+), use **`ozone-filesystem-hadoop3` only**. The separate **`ozone-filesystem-hadoop3-client`** artifact was removed; protobuf is relocated inside the main JAR to `org.apache.ozone.shaded.com.google.protobuf`. Do **not** look for or build the old client JAR.
-
-If you hit protobuf class-cast errors at runtime with a specific Trino release, see [Trino discussion #18026](https://github.com/trinodb/trino/discussions/18026).
-
-:::warning Hadoop line compatibility (Ozone 2.x + Trino 483)
-Ozone **2.x** filesystem classes implement Hadoop **3.4** interfaces such as `org.apache.hadoop.fs.LeaseRecoverable`. Trino **483** still ships Hadoop **3.3.x**, which causes `NoClassDefFoundError: org/apache/hadoop/fs/LeaseRecoverable` on the first `ofs://` write unless you align versions. Options for a lab:
-
-- Use a Trino release that bundles Hadoop **3.4+** when available, or
-- Add a small supplemental JAR with the missing Hadoop 3.4 interface classes (`LeaseRecoverable`, `SafeMode`, `SafeModeAction`) to `plugin/hive/hdfs/` alongside the Ozone JAR (lab use only).
-
-This was verified with `ozone-filesystem-hadoop3-2.2.0.jar` from Maven Central and `trinodb/trino:483`.
-:::
-
-## 1. Obtain the Ozone filesystem JAR
-
-### Download from Maven Central (recommended for labs)
-
-Match the JAR version to your cluster (example: Ozone **2.2.0**):
+## 1. Download the Ozone filesystem JAR
 
 ```bash
 OZONE_VERSION=2.2.0
@@ -51,127 +27,41 @@ curl -L -o /tmp/ozone-filesystem-hadoop3-${OZONE_VERSION}.jar \
   "https://repo1.maven.org/maven2/org/apache/ozone/ozone-filesystem-hadoop3/${OZONE_VERSION}/ozone-filesystem-hadoop3-${OZONE_VERSION}.jar"
 ```
 
-You can also copy the JAR from a running Ozone container:
+You can also copy the JAR from a running Ozone container under `/opt/hadoop/share/ozone/lib/`.
+
+## 2. Start Ozone and create a bucket
+
+Using [Apache Ozone Docker](https://github.com/apache/ozone-docker):
 
 ```bash
-docker cp <ozone-om-container>:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-*.jar /tmp/
+git clone https://github.com/apache/ozone-docker.git
+cd ozone-docker
+docker compose -p ozone-trino up -d --scale datanode=3
 ```
 
-### Build from source
-
-From your Ozone source checkout:
+Create an FSO bucket with **`RATIS/ONE`** replication for the lab:
 
 ```bash
-mvn clean package -DskipTests -pl hadoop-ozone/ozonefs-hadoop3 -am
-cd hadoop-ozone/ozonefs-hadoop3/target/
-cp ozone-filesystem-hadoop3-*.jar /tmp/
+docker compose -p ozone-trino exec om \
+  ozone sh bucket create s3v/trino-lab -l fso -t RATIS -r ONE
 ```
 
-## 2. Bring up Ozone, Hive, and (optionally) Ranger in Docker
-
-### Option A: Ranger project compose stacks
-
-The Apache Ranger repo ships Docker Compose files under `dev-support/ranger-docker`.
-
-1. Clone Ranger: [Apache Ranger](https://github.com/apache/ranger).
-2. Open `dev-support/ranger-docker` and follow the **README** there.
-3. Build and start the stack (verify file names against the current README):
+If writes hang, check SCM safe mode and exit when pipelines are ready:
 
 ```bash
-docker compose \
-  -f docker-compose.ranger.yml \
-  -f docker-compose.ranger-hadoop.yml \
-  -f docker-compose.ranger-hive.yml \
-  -f docker-compose.ranger-ozone.yml \
-  up -d
+docker compose -p ozone-trino exec scm ozone admin safemode status
+docker compose -p ozone-trino exec scm ozone admin safemode exit
 ```
 
-Use `docker network inspect` to find the compose network name (often `rangernw`) and HMS hostname (often `ranger-hive`).
-
-### Option B: Minimal lab without Ranger (Ozone + Hive Metastore)
-
-Verified against [Apache Ozone Docker](https://github.com/apache/ozone-docker) with `trinodb/trino:483` and `ozone-filesystem-hadoop3-2.2.0.jar`.
-
-1. Start Ozone with **three Datanodes** (recommended for writes; default replication needs healthy Ratis pipelines):
-
-   ```bash
-   git clone https://github.com/apache/ozone-docker.git
-   cd ozone-docker
-   docker compose -p ozone-trino up -d --scale datanode=3
-   ```
-
-   On a nearly full Docker disk, add smaller container defaults to compose (for example `ozone.scm.container.size: "1GB"` and `hdds.datanode.volume.min.free.space: "256MB"`) so SCM can allocate pipelines.
-
-2. Find the Docker network (example: `ozone-trino_default`):
-
-   ```bash
-   docker network ls | grep ozone-trino
-   ```
-
-3. Create an FSO bucket with **`RATIS/ONE`** replication (default `THREE` needs three Datanodes):
-
-   ```bash
-   docker compose -p ozone-trino exec om \
-     ozone sh bucket create s3v/trino-lab -l fso -t RATIS -r ONE
-   ```
-
-4. Prepare Hadoop/Ozone XML on the host (see [Hadoop and Ozone configuration](#hadoop-and-ozone-configuration-inside-trino)). HMS needs the **same** `core-site.xml`, `ozone-site.xml`, and Ozone JAR.
-
-5. Start Hive Metastore on the **same network**:
-
-   ```bash
-   docker run -d --name hive-metastore \
-     --network ozone-trino_default \
-     -p 9083:9083 \
-     -e SERVICE_NAME=metastore \
-     -v /path/to/hive-conf:/opt/hive/conf:ro \
-     -v /tmp/ozone-filesystem-hadoop3-2.2.0.jar:/opt/hive/lib/ozone-filesystem-hadoop3.jar:ro \
-     apache/hive:4.0.1
-   ```
-
-The `hive-conf` directory must include `hive-site.xml` (warehouse dir on Ozone), `core-site.xml`, and `ozone-site.xml`.
-
-:::warning Network and hostnames
-Trino’s catalog must use the **same Docker network** as HMS and the hostnames in `ozone-site.xml` / `core-site.xml` (for example `om`, `scm`). If Trino cannot resolve the HMS hostname, `thrift://` connections fail.
+:::note Docker lab sizing
+Three Datanodes avoid replication and pipeline issues on a small compose stack. If Docker disk space is tight, set smaller SCM container defaults in compose (for example `ozone.scm.container.size: "1GB"`).
 :::
 
-## 3. Run Trino and install the Ozone JAR
+## 3. Prepare Hadoop XML
 
-Start Trino on the Ozone/Hive network and bind-mount a host directory for Hadoop XML:
+Author **`core-site.xml`** and **`ozone-site.xml`** on the host. Use the compose service names (`om`, `scm`) as hostnames. List **both files separately** in `hive.config.resources` (a single merged file is unreliable in this setup).
 
-```bash
-docker run -d -p 8080:8080 --name trino \
-  --network ozone-trino_default \
-  --memory=1536m \
-  -e JAVA_TOOL_OPTIONS="-Xmx768m -XX:+UseSerialGC" \
-  -v /path/to/hadoop-conf:/tmp/hadoop/conf:ro \
-  trinodb/trino
-```
-
-With three Ozone Datanodes plus Hive Metastore, Trino may need a modest heap limit to avoid OOM on a typical Docker Desktop memory budget.
-
-Copy the Ozone filesystem JAR (and, if needed for Ozone 2.x + Trino 483, the Hadoop 3.4 interface supplemental JAR) into the Hive HDFS plugin directory:
-
-```bash
-docker cp /tmp/ozone-filesystem-hadoop3-2.2.0.jar \
-  trino:/usr/lib/trino/plugin/hive/hdfs/
-# Lab only, if you see LeaseRecoverable errors:
-# docker cp /tmp/hadoop34-interfaces.jar trino:/usr/lib/trino/plugin/hive/hdfs/
-docker restart trino
-```
-
-:::tip Docker Desktop on macOS
-
-- Use **`docker cp`** for catalog properties and JARs, or bind-mount a **directory** for `/etc/trino/catalog`—not individual property files (Docker may create a directory instead of a file).
-- Bind mounts under `/tmp` can appear empty inside the container; mount from a normal workspace path.
-
-:::
-
-### Hadoop and Ozone configuration inside Trino
-
-`hive.config.resources` must list **separate** `core-site.xml` and `ozone-site.xml` files (comma-separated). Plain **`apache/ozone` Docker images** expose Ozone settings through environment variables; their packaged `core-site.xml` is often empty—author both files yourself.
-
-**`core-site.xml`** (adjust hostnames to match compose service names):
+**`core-site.xml`:**
 
 ```xml
 <?xml version="1.0"?>
@@ -191,7 +81,7 @@ docker restart trino
 </configuration>
 ```
 
-**`ozone-site.xml`** (single OM on the `om` service):
+**`ozone-site.xml`:**
 
 ```xml
 <?xml version="1.0"?>
@@ -223,13 +113,44 @@ docker restart trino
 </configuration>
 ```
 
-Mount these under `/tmp/hadoop/conf/` (or another path referenced from the catalog).
+## 4. Start Hive Metastore and Trino
 
-## 4. Hive catalog properties (`ozone.properties`)
+Start HMS on the **same Docker network** as Ozone (example network: `ozone-trino_default`). Mount the Ozone JAR plus the XML files:
 
-The **file name** (without `.properties`) becomes the catalog name—for example `ozone.properties` → `SHOW CATALOGS` lists `ozone`.
+```bash
+docker run -d --name hive-metastore \
+  --network ozone-trino_default \
+  -p 9083:9083 \
+  -e SERVICE_NAME=metastore \
+  -v /path/to/hive-conf:/opt/hive/conf:ro \
+  -v /tmp/ozone-filesystem-hadoop3-2.2.0.jar:/opt/hive/lib/ozone-filesystem-hadoop3.jar:ro \
+  apache/hive:4.0.1
+```
 
-Example for the minimal lab:
+Include `hive-site.xml` in `hive-conf` with a warehouse path on Ozone, for example `ofs://om/s3v/trino-lab/warehouse`.
+
+Start Trino on the same network and mount the Hadoop XML directory:
+
+```bash
+docker run -d --name trino \
+  --network ozone-trino_default \
+  -p 8080:8080 \
+  --memory=1536m \
+  -e JAVA_TOOL_OPTIONS="-Xmx768m -XX:+UseSerialGC" \
+  -v /path/to/hadoop-conf:/tmp/hadoop/conf:ro \
+  trinodb/trino
+```
+
+Copy the Ozone JAR (and the Hadoop 3.4 interface supplemental JAR, if needed) into Trino’s Hive plugin, then add the catalog:
+
+```bash
+docker cp /tmp/ozone-filesystem-hadoop3-2.2.0.jar \
+  trino:/usr/lib/trino/plugin/hive/hdfs/
+docker cp ozone.properties trino:/etc/trino/catalog/ozone.properties
+docker restart trino
+```
+
+**`ozone.properties`** (the file name becomes the catalog name):
 
 ```properties
 connector.name=hive
@@ -242,36 +163,17 @@ hive.dfs.replication=1
 hive.temporary-staging-directory-path=ofs://om/s3v/trino-lab/.staging
 ```
 
-Point **`hive.temporary-staging-directory-path`** at a bucket that uses **`RATIS/ONE`**. Trino otherwise stages under an auto-created `tmp` volume with default **`RATIS/THREE`**, which can fail when moving files into a one-replica lab bucket.
+Set **`hive.temporary-staging-directory-path`** to your **`RATIS/ONE`** bucket. Trino otherwise stages under an auto-created `tmp` volume with default **`RATIS/THREE`**, which breaks moves into a one-replica lab bucket.
 
-Copy the catalog file and restart:
-
-```bash
-docker cp ozone.properties trino:/etc/trino/catalog/ozone.properties
-docker restart trino
-```
-
-:::warning Lab vs production settings
-
-- **`hive.hdfs.impersonation.enabled=false`** is for non-Kerberos labs only.
-- **`hive.config.resources`** must point to files that exist inside the container before the catalog starts.
-
+:::tip Docker Desktop on macOS
+Use **`docker cp`** for catalog files and JARs. Bind-mount a directory for config, not a single file under `/tmp` (mounts can appear empty in the container).
 :::
 
-## 5. Ranger access control (optional)
-
-Ranger requires the full Trino Ranger plugin install, not only property files. See [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html).
-
-## 6. Restart Trino and verify
-
-After JAR, catalog, or XML changes, restart Trino. Then confirm connectivity and Ozone-backed DDL:
+## 5. Verify
 
 ```sql
 SHOW CATALOGS;
--- expect: ozone
-
 SHOW SCHEMAS FROM ozone;
--- expect: default, information_schema, ...
 
 CREATE SCHEMA ozone.lab WITH (location = 'ofs://om/s3v/trino-lab/lab');
 
@@ -285,43 +187,16 @@ INSERT INTO ozone.lab.demo VALUES (1, 'alice'), (2, 'bob');
 SELECT * FROM ozone.lab.demo ORDER BY id;
 ```
 
-The following were **verified locally** with `ozone-filesystem-hadoop3-2.2.0.jar`, Ozone Docker **2.2.0** (three Datanodes), and Trino **483**:
+## Troubleshooting
 
-| Step | Result |
-| ---- | ------ |
-| `SHOW CATALOGS` / `SHOW SCHEMAS FROM ozone` | OK |
-| `CREATE SCHEMA ... WITH (location = 'ofs://...')` | OK |
-| `CREATE TABLE ... WITH (format = 'PARQUET')` | OK |
-| `INSERT` / `SELECT` with data | OK (with staging path and cluster notes below) |
+| Symptom | Likely cause |
+| ------- | ------------ |
+| `NoClassDefFoundError: LeaseRecoverable` | Trino Hadoop **3.3** vs Ozone **3.4** interfaces; add supplemental JAR or upgrade Trino. |
+| `UnsupportedFileSystemException: ofs` | Missing or wrong `hive.config.resources`, or HMS missing Ozone JAR/XML. |
+| INSERT fails moving staged files | Staging path not set to a **`RATIS/ONE`** bucket. |
+| Writes hang | SCM safe mode; not enough healthy Datanodes or disk for pipelines. |
+| Metastore connection errors | Trino not on the same Docker network as HMS, or wrong hostname in `hive.metastore.uri`. |
 
-:::note Docker lab caveats
+## Ranger (optional)
 
-- Scale compose with **`--scale datanode=3`**; default three-way replication needs three healthy Datanodes.
-- If writes hang, check SCM safe mode: `docker exec <scm> ozone admin safemode status` and `ozone admin safemode exit` if pipelines are slow to form.
-- On a nearly full Docker disk, lower **`ozone.scm.container.size`** (for example `1GB`) so SCM can allocate containers.
-- Set **`hive.temporary-staging-directory-path`** to a **`RATIS/ONE`** bucket path (see catalog example above).
-
-:::
-
-If initialization fails, check Trino logs for:
-
-- **`NoClassDefFoundError: LeaseRecoverable`**: See [Hadoop line compatibility](#ozone-jar-and-trino).
-- **`UnsupportedFileSystemException: No FileSystem for scheme "ofs"`**: Missing XML, wrong `hive.config.resources` paths, or HMS missing the Ozone JAR/config.
-- **Protobuf / class loading errors**: Ozone–Trino version skew; confirm you use **`ozone-filesystem-hadoop3`** only ([HDDS-14056](https://issues.apache.org/jira/browse/HDDS-14056)).
-- **Metastore errors**: Wrong HMS host, port, or network.
-
-### Alternative: S3 Gateway (`s3a://`)
-
-If `ofs://` remains blocked by version skew, some deployments use Ozone’s **S3 Gateway** with Trino S3 settings. See [S3A](../01-client-interfaces/04-s3a) and [Trino discussion #18026](https://github.com/trinodb/trino/discussions/18026).
-
-## Summary
-
-| Area | What to verify |
-| ---- | -------------- |
-| Ozone JAR | **`ozone-filesystem-hadoop3-*.jar`** only ([HDDS-14056](https://issues.apache.org/jira/browse/HDDS-14056)); match cluster version. |
-| Install path | Drop into Trino **`plugin/hive/hdfs/`**; same JAR on HMS classpath. |
-| Hadoop XML | **`fs.ofs.impl`**, **`fs.AbstractFileSystem.ofs.impl`**, OM/SCM in separate **`core-site.xml`** + **`ozone-site.xml`**. |
-| Trino + Ozone 2.x | Watch for Hadoop **3.3 vs 3.4** (`LeaseRecoverable`) on Trino 483. |
-| Docker lab | Same network; **`--scale datanode=3`**; **`RATIS/ONE`** buckets; staging path; exit SCM safe mode before writes. |
-
-For work tracked around this integration on the Ozone side, see [HDDS-12321](https://issues.apache.org/jira/browse/HDDS-12321).
+To enforce access control with [Apache Ranger](https://ranger.apache.org/), install the Trino Ranger plugin per [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html). The Ranger project’s `dev-support/ranger-docker` compose stacks can provide Ozone, Hive, and Ranger on one network if you need a combined lab.

--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -4,7 +4,7 @@ sidebar_label: Trino
 
 # Trino with Ozone
 
-[Trino](https://trino.io/) reads and writes Ozone data through the **Hive connector** and a **Hive Metastore (HMS)**. The recommended path uses native Ozone **`ofs://`** URIs; an alternative uses Ozone's **S3 Gateway** with **`s3a://`** / **`s3://`** URIs. For background on Hive warehouse paths and the Ozone filesystem JAR, see [Hive](./01-hive).
+[Trino](https://trino.io/) reads and writes Ozone data through the **Hive connector** and a **Hive Metastore (HMS)**. The recommended path uses native Ozone **`ofs://`** URIs; an alternative uses Ozone's **S3 Gateway** with **`s3a://`** / **`s3://`** URIs. For background on Hive warehouse paths and the Ozone filesystem JAR, see [Hive](./hive).
 
 This page walks through a **Docker lab** verified with **Ozone 2.2.0** and **`trinodb/trino:483`**. The **`ofs://`** flow (including **`INSERT` / `SELECT`**) was verified end-to-end; the **S3 Gateway** flow was verified for creating schemas/tables and reads, but not writes (see [Alternative: Ozone S3 Gateway](#alternative-ozone-s3-gateway-s3a)).
 
@@ -213,7 +213,7 @@ SELECT * FROM ozone.lab.demo ORDER BY id;
 
 ## Alternative: Ozone S3 Gateway (`s3a://`)
 
-Use this when you prefer the Hadoop **S3A** bucket layout (`s3a://bucket/path`) or Ozone's **S3 Gateway** (`s3g`) instead of the Ozone filesystem JAR on Trino. See also [s3a and Ozone](../01-client-interfaces/04-s3a).
+Use this when you prefer the Hadoop **S3A** bucket layout (`s3a://bucket/path`) or Ozone's **S3 Gateway** (`s3g`) instead of the Ozone filesystem JAR on Trino. See also [s3a and Ozone](../client-interfaces/s3a).
 
 :::note Trino 483 uses native S3, not Hadoop S3A JARs
 Trino **483** removed legacy `hive.s3.*` settings. Configure **`fs.s3.enabled=true`** and **`s3.*`** catalog properties instead. Do **not** add `hadoop-aws` to Trino's classpath—HMS still needs the Hadoop S3A client to validate `s3a://` paths when creating schemas and tables.

--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -16,7 +16,7 @@ This page walks through a **Docker lab** verified with **Ozone 2.2.0**, **`ozone
 - **`core-site.xml`** and **`ozone-site.xml`** inside the Trino container, referenced from the catalog.
 
 :::warning Trino 483 and Hadoop 3.4 interfaces
-Ozone **2.2.0** targets Hadoop **3.4** APIs. Trino **483** ships Hadoop **3.3.x**, which can cause `NoClassDefFoundError: org/apache/hadoop/fs/LeaseRecoverable` on the first `ofs://` write. For a lab, add a small supplemental JAR with the missing interface classes (`LeaseRecoverable`, `SafeMode`, `SafeModeAction`) to `plugin/hive/hdfs/` next to the Ozone JAR. Prefer a Trino release that bundles Hadoop **3.4+** when one is available for your deployment.
+Ozone **2.2.0** targets Hadoop **3.4** APIs. Trino **483** ships Hadoop **3.3.x**, which can cause `NoClassDefFoundError: org/apache/hadoop/fs/LeaseRecoverable` on the first `ofs://` write. This is a **Trino classpath gap**, not an Ozone build step—see [Build the Hadoop 3.4 interface stub](#build-the-hadoop-34-interface-stub-trino-483-lab) below. Prefer a Trino release that bundles Hadoop **3.4+** when one is available for your deployment.
 :::
 
 ## 1. Download the Ozone filesystem JAR
@@ -28,6 +28,28 @@ curl -L -o /tmp/ozone-filesystem-hadoop3-${OZONE_VERSION}.jar \
 ```
 
 You can also copy the JAR from a running Ozone container under `/opt/hadoop/share/ozone/lib/`.
+
+### Build the Hadoop 3.4 interface stub (Trino 483 lab)
+
+Ozone 2.1+ expects Hadoop **3.4** interface types on the client classpath ([HDDS-13574](https://issues.apache.org/jira/browse/HDDS-13574)). Trino **483** does not ship them. For a lab, build a **small stub JAR** from Apache **`hadoop-common` 3.4** on Maven Central—do **not** rebuild Ozone, and avoid dropping the full `hadoop-common` JAR onto Trino (Trino already embeds Hadoop 3.3 and duplicate JARs can cause other conflicts).
+
+```bash
+HADOOP34=/tmp/hadoop-common-3.4.0.jar
+curl -L -o "$HADOOP34" \
+  "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-common/3.4.0/hadoop-common-3.4.0.jar"
+
+mkdir -p /tmp/hadoop34-stub && cd /tmp/hadoop34-stub
+jar xf "$HADOOP34" \
+  org/apache/hadoop/fs/LeaseRecoverable.class \
+  org/apache/hadoop/fs/SafeMode.class \
+  org/apache/hadoop/fs/SafeModeAction.class
+jar cf /tmp/hadoop34-interfaces.jar \
+  org/apache/hadoop/fs/LeaseRecoverable.class \
+  org/apache/hadoop/fs/SafeMode.class \
+  org/apache/hadoop/fs/SafeModeAction.class
+```
+
+Copy **both** JARs into Trino’s Hive HDFS plugin directory (see step 4). Skip this stub if your Trino release already bundles Hadoop **3.4+**.
 
 ## 2. Start Ozone and create a bucket
 
@@ -141,10 +163,12 @@ docker run -d --name trino \
   trinodb/trino
 ```
 
-Copy the Ozone JAR (and the Hadoop 3.4 interface supplemental JAR, if needed) into Trino’s Hive plugin, then add the catalog:
+Copy the Ozone JAR, the Hadoop 3.4 interface stub (Trino 483), and the catalog into Trino, then restart:
 
 ```bash
 docker cp /tmp/ozone-filesystem-hadoop3-2.2.0.jar \
+  trino:/usr/lib/trino/plugin/hive/hdfs/
+docker cp /tmp/hadoop34-interfaces.jar \
   trino:/usr/lib/trino/plugin/hive/hdfs/
 docker cp ozone.properties trino:/etc/trino/catalog/ozone.properties
 docker restart trino
@@ -191,7 +215,7 @@ SELECT * FROM ozone.lab.demo ORDER BY id;
 
 | Symptom | Likely cause |
 | ------- | ------------ |
-| `NoClassDefFoundError: LeaseRecoverable` | Trino Hadoop **3.3** vs Ozone **3.4** interfaces; add supplemental JAR or upgrade Trino. |
+| `NoClassDefFoundError: LeaseRecoverable` | Trino Hadoop **3.3** vs Ozone **3.4** interfaces; build and copy `hadoop34-interfaces.jar` (step 1) or upgrade Trino. |
 | `UnsupportedFileSystemException: ofs` | Missing or wrong `hive.config.resources`, or HMS missing Ozone JAR/XML. |
 | INSERT fails moving staged files | Staging path not set to a **`RATIS/ONE`** bucket. |
 | Writes hang | SCM safe mode; not enough healthy Datanodes or disk for pipelines. |

--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -135,6 +135,10 @@ Author **`core-site.xml`** and **`ozone-site.xml`** on the host. Use the compose
 </configuration>
 ```
 
+:::warning Keep S3A settings out of Trino's `core-site.xml`
+Use the **`ofs`-only** `core-site.xml` above inside the Trino container for the **`ozone`** catalog. Do **not** add `fs.s3a.*` properties there—Trino's Hive plugin does not ship `hadoop-aws`, and mixed XML causes `ClassNotFoundException: org.apache.hadoop.fs.s3a.S3AFileSystem` on `ofs://` writes. HMS can use a **separate** `core-site.xml` that adds S3A settings when you also run the S3 Gateway path (see below).
+:::
+
 ## 4. Start Hive Metastore and Trino
 
 Start HMS on the **same Docker network** as Ozone (example network: `ozone-trino_default`). Mount the Ozone JAR plus the XML files:
@@ -195,6 +199,8 @@ Use **`docker cp`** for catalog files and JARs. Bind-mount a directory for confi
 
 ## 5. Verify
 
+Use the **`ozone`** catalog ( **`ofs://`** ) for the steps below. Do **not** run these writes on **`ozone_s3a`**—S3 Gateway inserts fail in this lab (see [Troubleshooting](#troubleshooting)).
+
 ```sql
 SHOW CATALOGS;
 SHOW SCHEMAS FROM ozone;
@@ -210,6 +216,10 @@ INSERT INTO ozone.lab.demo VALUES (1, 'alice'), (2, 'bob');
 
 SELECT * FROM ozone.lab.demo ORDER BY id;
 ```
+
+:::note One HMS, two catalogs
+If you add the optional **`ozone_s3a`** catalog later, it shares the same Hive Metastore. Schema and table names must not collide, and each schema's `location` must match the catalog you query (`ofs://…` for **`ozone`**, `s3a://…` for **`ozone_s3a`**). If you already created `lab` with an `s3a://` location while testing S3, create a new schema (for example `ofslab`) on the **`ozone`** catalog instead of reusing `lab`.
+:::
 
 ## Alternative: Ozone S3 Gateway (`s3a://`)
 
@@ -288,6 +298,10 @@ Use **`s3a://`** (not `s3://`) in **`CREATE SCHEMA ... WITH (location = ...)`** 
 
 ### Verify (S3 Gateway)
 
+:::warning No writes in the Docker lab
+Do **not** run `INSERT` (or `CREATE TABLE AS`) on **`ozone_s3a`** in this lab. Trino commits through the native S3 client; Ozone S3 Gateway returns HTTP **500** on multi-part puts, which surfaces as **`HIVE_WRITER_CLOSE_ERROR`** after several minutes. Use the **`ozone`** catalog and **`ofs://`** for verified writes.
+:::
+
 ```sql
 CREATE SCHEMA ozone_s3a.lab WITH (location = 's3a://trino-lab/s3-lab');
 
@@ -324,12 +338,13 @@ Use **`ofs://`** (above) when you need verified writes from Trino. Re-test the S
 | Symptom | Likely cause |
 | ------- | ------------ |
 | `NoClassDefFoundError: LeaseRecoverable` | Trino Hadoop **3.3** vs Ozone **3.4** interfaces; build and copy `hadoop34-interfaces.jar` (step 1) or upgrade Trino. |
+| `ClassNotFoundException: S3AFileSystem` on **`ozone`** writes | `fs.s3a.*` in Trino's `core-site.xml`, or querying a table whose HMS location is `s3a://…` through the **`ozone`** catalog. Use ofs-only XML in Trino and `ofs://` schema/table locations. |
 | `UnsupportedFileSystemException: ofs` | Missing or wrong `hive.config.resources`, or HMS missing Ozone JAR/XML. |
 | INSERT fails moving staged files | Staging path not set to a **`RATIS/ONE`** bucket. |
 | Writes hang | SCM safe mode; not enough healthy Datanodes or disk for pipelines. |
 | Metastore connection errors | Trino not on the same Docker network as HMS, or wrong hostname in `hive.metastore.uri`. |
 | S3 `CREATE SCHEMA` fails on HMS | HMS missing S3A JARs or `fs.s3a.*` settings in `core-site.xml`; use `s3a://` locations. |
-| S3 `INSERT` hangs or fails on commit | Known issue in the Docker lab with Trino **483** native S3; prefer **`ofs://`** for writes. |
+| S3 `INSERT` → `HIVE_WRITER_CLOSE_ERROR` (HTTP 500 from S3G) | Expected in the Docker lab with Trino **483** native S3 on **`ozone_s3a`**; use **`ozone`** + **`ofs://`** for writes. |
 
 ## Ranger (optional)
 

--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -4,7 +4,7 @@ sidebar_label: Trino
 
 # Trino with Ozone
 
-[Trino](https://trino.io/) reads and writes Ozone data through the **Hive connector** and a **Hive Metastore (HMS)**. The recommended path uses native Ozone **`ofs://`** URIs; an alternative uses Ozone's **S3 Gateway** with **`s3a://`** / **`s3://`** URIs. For background on Hive warehouse paths and the Ozone filesystem JAR, see [Hive](./hive).
+[Trino](https://trino.io/) reads and writes Ozone data through the **Hive connector** and a **Hive Metastore (HMS)**. The recommended path uses native Ozone **`ofs://`** URIs; an alternative uses Ozone's **S3 Gateway** with **`s3a://`** URIs (HMS creates paths through Hadoop S3A). For background on Hive warehouse paths and the Ozone filesystem JAR, see [Hive](./hive).
 
 This page walks through a **Docker lab** verified with **Ozone 2.2.0** and **`trinodb/trino:483`**. The **`ofs://`** flow (including **`INSERT` / `SELECT`**) was verified end-to-end; the **S3 Gateway** flow was verified for creating schemas/tables and reads, but not writes (see [Alternative: Ozone S3 Gateway](#alternative-ozone-s3-gateway-s3a)).
 
@@ -12,8 +12,8 @@ This page walks through a **Docker lab** verified with **Ozone 2.2.0** and **`tr
 
 - Docker Compose with enough memory for Ozone (three Datanodes), Hive Metastore, and Trino.
 - **`ozone-filesystem-hadoop3-*.jar`** at the **same version as your cluster** ([HDDS-14056](https://issues.apache.org/jira/browse/HDDS-14056): use this JAR only; the old **`ozone-filesystem-hadoop3-client`** artifact was removed in Ozone 2.2+).
-- HMS on `thrift://<host>:9083`, with the same Ozone JAR and Hadoop XML as Trino.
-- **`core-site.xml`** and **`ozone-site.xml`** inside the Trino container, referenced from the catalog.
+- HMS on `thrift://<host>:9083`. For the **`ofs://`** path, HMS needs the Ozone JAR and **`ofs`** Hadoop XML. If you also use the S3 Gateway path, HMS additionally needs S3A JARs and `fs.s3a.*` settings (see [Alternative: Ozone S3 Gateway](#alternative-ozone-s3-gateway-s3a)).
+- **`core-site.xml`** and **`ozone-site.xml`** inside the Trino container for the **`ozone`** catalog, referenced from `hive.config.resources`.
 
 :::warning Trino 483 and Hadoop 3.4 interfaces
 Ozone **2.2.0** targets Hadoop **3.4** APIs. Trino **483** ships Hadoop **3.3.x**, which can cause `NoClassDefFoundError: org/apache/hadoop/fs/LeaseRecoverable` on the first `ofs://` write. This is a **Trino classpath gap**, not an Ozone build step—see [Build the Hadoop 3.4 interface stub](#build-the-hadoop-34-interface-stub-trino-483-lab) below. Prefer a Trino release that bundles Hadoop **3.4+** when one is available for your deployment.
@@ -136,7 +136,7 @@ Author **`core-site.xml`** and **`ozone-site.xml`** on the host. Use the compose
 ```
 
 :::warning Keep S3A settings out of Trino's `core-site.xml`
-Use the **`ofs`-only** `core-site.xml` above inside the Trino container for the **`ozone`** catalog. Do **not** add `fs.s3a.*` properties there—Trino's Hive plugin does not ship `hadoop-aws`, and mixed XML causes `ClassNotFoundException: org.apache.hadoop.fs.s3a.S3AFileSystem` on `ofs://` writes. HMS can use a **separate** `core-site.xml` that adds S3A settings when you also run the S3 Gateway path (see below).
+Use the **`ofs`-only** `core-site.xml` above inside the Trino container for the **`ozone`** catalog. Do **not** add `fs.s3a.*` properties there—Trino's Hive plugin does not ship `hadoop-aws`, and mixed XML causes `ClassNotFoundException: org.apache.hadoop.fs.s3a.S3AFileSystem` when Trino touches `s3a://` paths. HMS can use a **separate** `core-site.xml` (for example under `hive-conf/`) that adds S3A settings when you also run the S3 Gateway path (see below).
 :::
 
 ## 4. Start Hive Metastore and Trino
@@ -153,7 +153,31 @@ docker run -d --name hive-metastore \
   apache/hive:4.0.1
 ```
 
-Include `hive-site.xml` in `hive-conf` with a warehouse path on Ozone, for example `ofs://om/s3v/trino-lab/warehouse`.
+Include **`core-site.xml`**, **`ozone-site.xml`**, and **`hive-site.xml`** in `hive-conf`. Example **`hive-site.xml`** (embedded Derby is fine for the lab):
+
+```xml
+<?xml version="1.0"?>
+<configuration>
+  <property>
+    <name>javax.jdo.option.ConnectionURL</name>
+    <value>jdbc:derby:;databaseName=/tmp/metastore_db;create=true</value>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionDriverName</name>
+    <value>org.apache.derby.jdbc.EmbeddedDriver</value>
+  </property>
+  <property>
+    <name>hive.metastore.warehouse.dir</name>
+    <value>ofs://om/s3v/trino-lab/warehouse</value>
+  </property>
+  <property>
+    <name>hive.metastore.schema.verification</name>
+    <value>false</value>
+  </property>
+</configuration>
+```
+
+For HMS, you can merge **`ofs`** and **`fs.s3a.*`** properties into one `core-site.xml` under `hive-conf/` when running both paths. Keep Trino's copy **`ofs`-only** (see step 3).
 
 Start Trino on the same network and mount the Hadoop XML directory:
 
@@ -167,18 +191,18 @@ docker run -d --name trino \
   trinodb/trino
 ```
 
-Copy the Ozone JAR, the Hadoop 3.4 interface stub (Trino 483), and the catalog into Trino, then restart:
+Copy the Ozone JAR, the Hadoop 3.4 interface stub (Trino 483), and the catalog property file into Trino, then restart:
 
 ```bash
 docker cp /tmp/ozone-filesystem-hadoop3-2.2.0.jar \
   trino:/usr/lib/trino/plugin/hive/hdfs/
 docker cp /tmp/hadoop34-interfaces.jar \
   trino:/usr/lib/trino/plugin/hive/hdfs/
-docker cp ozone.properties trino:/etc/trino/catalog/ozone.properties
+docker cp /path/to/ozone.properties trino:/etc/trino/catalog/ozone.properties
 docker restart trino
 ```
 
-**`ozone.properties`** (the file name becomes the catalog name):
+Create **`ozone.properties`** on the host (path in the `docker cp` command above):
 
 ```properties
 connector.name=hive
@@ -199,7 +223,7 @@ Use **`docker cp`** for catalog files and JARs. Bind-mount a directory for confi
 
 ## 5. Verify
 
-Use the **`ozone`** catalog ( **`ofs://`** ) for the steps below. Do **not** run these writes on **`ozone_s3a`**—S3 Gateway inserts fail in this lab (see [Troubleshooting](#troubleshooting)).
+Use the **`ozone`** catalog and **`ofs://`** for the steps below. Do **not** run these writes on **`ozone_s3a`**—S3 Gateway inserts fail in this lab (see [Troubleshooting](#troubleshooting)).
 
 ```sql
 SHOW CATALOGS;
@@ -223,7 +247,9 @@ The optional **`ozone_s3a`** catalog uses the same Hive Metastore. Use **differe
 
 ## Alternative: Ozone S3 Gateway (`s3a://`)
 
-Use this when you prefer the Hadoop **S3A** bucket layout (`s3a://bucket/path`) or Ozone's **S3 Gateway** (`s3g`) instead of the Ozone filesystem JAR on Trino. See also [s3a and Ozone](../client-interfaces/s3a).
+Use this when you prefer the Hadoop **S3A** bucket layout (`s3a://bucket/path`) or Ozone's **S3 Gateway** (`s3g`) instead of the Ozone filesystem JAR on **Trino**. Trino reads and writes through its native **`s3.*`** client; **HMS** still uses Hadoop S3A to create and validate `s3a://` paths. See also [s3a and Ozone](../client-interfaces/s3a).
+
+The Ozone bucket created in step 2 (`s3v/trino-lab`) is exposed to S3 clients as bucket **`trino-lab`**—that is why **`ofs://`** paths include the volume (`s3v/trino-lab/...`) while **`s3a://`** paths use the bucket name alone (`s3a://trino-lab/...`).
 
 :::note Trino 483 uses native S3, not Hadoop S3A JARs
 Trino **483** removed legacy `hive.s3.*` settings. Configure **`fs.s3.enabled=true`** and **`s3.*`** catalog properties instead. Do **not** add `hadoop-aws` to Trino's classpath—HMS still needs the Hadoop S3A client to validate `s3a://` paths when creating schemas and tables.
@@ -280,7 +306,14 @@ Mount **`hadoop-aws-3.3.5.jar`** (match Trino's Hadoop **3.3.x** line) plus its 
 
 ### Trino catalog for S3
 
-Create a separate catalog file (example **`ozone_s3a.properties`**):
+Create **`ozone_s3a.properties`** on the host, copy it into Trino, and restart (same pattern as **`ozone.properties`** in step 4):
+
+```bash
+docker cp /path/to/ozone_s3a.properties trino:/etc/trino/catalog/ozone_s3a.properties
+docker restart trino
+```
+
+Example catalog file:
 
 ```properties
 connector.name=hive
@@ -310,7 +343,7 @@ CREATE TABLE ozone_s3a.lab.demo (
   name varchar
 ) WITH (format = 'TEXTFILE');
 
--- Read path: point an external table at objects already in the bucket
+-- Optional read check: upload objects under s3-read/ first (for example with aws s3 cp against s3g:9878)
 CREATE TABLE ozone_s3a.readlab.demo (
   id varchar,
   name varchar
@@ -331,7 +364,7 @@ Docker lab verification with **`fs.s3.enabled=true`** and Ozone S3G:
 | `SELECT` from external data in the bucket | OK |
 | `INSERT` into managed tables | Failed (`HIVE_WRITER_CLOSE_ERROR` after long commit timeout) |
 
-Use **`ofs://`** (above) when you need verified writes from Trino. Re-test the S3 **`INSERT`** path when upgrading Trino or Ozone, or in a production-sized cluster with more memory.
+Use **`ofs://`** (above) when you need verified writes from Trino. Re-test the S3 **`INSERT`** path when upgrading Trino or Ozone.
 
 ## Troubleshooting
 

--- a/docs/04-user-guide/02-integrations/07-trino.md
+++ b/docs/04-user-guide/02-integrations/07-trino.md
@@ -6,7 +6,7 @@ sidebar_label: Trino
 
 [Trino](https://trino.io/) can query tables whose data lives in Apache Ozone when you use the **Hive connector** and a **Hive Metastore (HMS)** that already understands Ozone paths (`ofs://`, `o3fs://`, or `s3a://`, depending on how tables were created). [Apache Ranger](https://ranger.apache.org/) can enforce access control for Trino through Trino’s Ranger integration.
 
-This page describes a **Docker-based lab-style setup**: build the standard Ozone **Hadoop 3 filesystem** JAR (`ozonefs-hadoop3` / `ozone-filesystem-hadoop3-*.jar`), join Trino to the same Docker network as Ozone, Ranger, Hadoop, and Hive, then configure a Hive catalog and Ranger access control.
+This page describes a **Docker-based lab-style setup**: obtain the standard Ozone **Hadoop 3 filesystem** JAR (`ozone-filesystem-hadoop3-*.jar`), join Trino to the same Docker network as Ozone and Hive, configure a Hive catalog, and optionally Ranger access control.
 
 :::note
 This is an **advanced** integration. Names (`ranger-hive`, `rangernw`), compose file names, and paths come from typical Ranger `dev-support/ranger-docker` layouts and **will differ** if you change compose projects or image tags. Treat hostnames and file names as examples and align them with your environment.
@@ -16,61 +16,68 @@ For how Hive uses Ozone (warehouse paths, `ofs://` URIs, and the filesystem JAR)
 
 ## Prerequisites
 
-- Docker and Docker Compose, with enough memory for Ranger, Hive, Ozone, and Trino.
-- Source tree for **Apache Ozone** and a JDK / Maven build able to run `mvn package` for the **`ozonefs-hadoop3`** module (or a release download of `ozone-filesystem-hadoop3`).
+- Docker and Docker Compose, with enough memory for Ozone, Hive, Trino, and (optionally) Ranger.
+- The **`ozone-filesystem-hadoop3-*.jar`** artifact at the **same Ozone version as your cluster** (see [Ozone JAR and Trino](#ozone-jar-and-trino)).
 - A running **Hive Metastore** that Trino can reach on `thrift://<host>:9083`.
-- **Hadoop `core-site.xml`** (and related config) that defines the Ozone filesystem implementation and service addresses, mounted or copied into the Trino container where `hive.config.resources` points.
-- If you use Ranger: Trino **Ranger plugin** configuration files (`ranger-trino-security.xml`, `ranger-trino-audit.xml`, `ranger-policymgr-ssl.xml`, and policies synced from Ranger Admin). See the [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html) documentation.
+- **Hadoop XML configuration** inside the Trino container that defines the Ozone filesystem (`fs.ofs.impl`, OM/SCM addresses) and is referenced by `hive.config.resources`.
+- If you use Ranger: Trino **Ranger plugin** configuration files and policies synced from Ranger Admin. See [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html).
 
 ## Ozone JAR and Trino
 
-Trino bundles its own Hadoop libraries. For the Hive connector to read and write `ofs://` / `o3fs://` paths, the **`ozone-filesystem-hadoop3-*.jar`** from the **`ozonefs-hadoop3`** Maven module must be on the Hive plugin classpath (see below).
+Trino bundles its own Hadoop libraries (currently Hadoop **3.3.x** in recent `trinodb/trino` images). For the Hive connector to read and write `ofs://` / `o3fs://` paths, the **`ozone-filesystem-hadoop3-*.jar`** from the **`ozonefs-hadoop3`** Maven module must be on the Hive HDFS plugin classpath (see below).
 
-The older **`ozonefs-hadoop3-client`** artifact and the **`proto.shaded.prefix`** Maven option are **no longer used** in current Ozone; build or download the standard **`ozonefs-hadoop3`** output only.
+Since [HDDS-14056](https://issues.apache.org/jira/browse/HDDS-14056) (Ozone 2.2+), use **`ozone-filesystem-hadoop3` only**. The separate **`ozone-filesystem-hadoop3-client`** artifact was removed; protobuf is relocated inside the main JAR to `org.apache.ozone.shaded.com.google.protobuf`. Do **not** look for or build the old client JAR.
 
-:::warning
-Pair **Ozone and Trino releases** that agree on a compatible Hadoop 3.x line. If Trino fails to load the Ozone filesystem or you see class or protobuf conflicts, align versions or ask on the Ozone dev list.
+If you hit protobuf class-cast errors at runtime with a specific Trino release, see [Trino discussion #18026](https://github.com/trinodb/trino/discussions/18026).
+
+:::warning Hadoop line compatibility (Ozone 2.x + Trino 483)
+Ozone **2.x** filesystem classes implement Hadoop **3.4** interfaces such as `org.apache.hadoop.fs.LeaseRecoverable`. Trino **483** still ships Hadoop **3.3.x**, which causes `NoClassDefFoundError: org/apache/hadoop/fs/LeaseRecoverable` on the first `ofs://` write unless you align versions. Options for a lab:
+
+- Use a Trino release that bundles Hadoop **3.4+** when available, or
+- Add a small supplemental JAR with the missing Hadoop 3.4 interface classes (`LeaseRecoverable`, `SafeMode`, `SafeModeAction`) to `plugin/hive/hdfs/` alongside the Ozone JAR (lab use only).
+
+This was verified with `ozone-filesystem-hadoop3-2.2.0.jar` from Maven Central and `trinodb/trino:483`.
 :::
 
-## 1. Build the Ozone filesystem JAR
+## 1. Obtain the Ozone filesystem JAR
 
-From your Ozone source checkout, build the Hadoop 3 filesystem module (and its dependencies):
+### Download from Maven Central (recommended for labs)
+
+Match the JAR version to your cluster (example: Ozone **2.2.0**):
+
+```bash
+OZONE_VERSION=2.2.0
+curl -L -o /tmp/ozone-filesystem-hadoop3-${OZONE_VERSION}.jar \
+  "https://repo1.maven.org/maven2/org/apache/ozone/ozone-filesystem-hadoop3/${OZONE_VERSION}/ozone-filesystem-hadoop3-${OZONE_VERSION}.jar"
+```
+
+You can also copy the JAR from a running Ozone container:
+
+```bash
+docker cp <ozone-om-container>:/opt/hadoop/share/ozone/lib/ozone-filesystem-hadoop3-*.jar /tmp/
+```
+
+### Build from source
+
+From your Ozone source checkout:
 
 ```bash
 mvn clean package -DskipTests -pl hadoop-ozone/ozonefs-hadoop3 -am
-```
-
-When the build succeeds, copy the artifact from the module output directory:
-
-```bash
 cd hadoop-ozone/ozonefs-hadoop3/target/
 cp ozone-filesystem-hadoop3-*.jar /tmp/
 ```
 
-The version in the file name (`*-SNAPSHOT.jar` or a release version) **depends on your Ozone branch**. You can also use the same artifact from Maven Central (coordinates `org.apache.ozone:ozone-filesystem-hadoop3`) at the version that matches your cluster instead of building from source.
+## 2. Bring up Ozone, Hive, and (optionally) Ranger in Docker
 
-:::note Historical note
-An older lab used [Ozone at commit fc89ba6a](https://github.com/apache/ozone/tree/fc89ba6aef9bd01562f76ef19888a56950bc6939); layout and Maven modules have changed since then. Prefer a **maintained release tag** that matches your cluster.
-:::
-
-## 2. Bring up Ozone, Ranger, Hive, and Hadoop in Docker
-
-### Option A: Ranger project compose stacks (recommended for a single lab network)
+### Option A: Ranger project compose stacks
 
 The Apache Ranger repo ships Docker Compose files under `dev-support/ranger-docker`.
 
-1. Clone Ranger: [https://github.com/apache/ranger](https://github.com/apache/ranger).
-2. Open `dev-support/ranger-docker` and follow the **README** there (prerequisites, passwords, profiles).
-3. Build and start the stack that includes Ranger, Hadoop, Hive, and Ozone. The README and file names on `master` **change over time**; your commands may look like the following pattern (verify against the current README):
+1. Clone Ranger: [Apache Ranger](https://github.com/apache/ranger).
+2. Open `dev-support/ranger-docker` and follow the **README** there.
+3. Build and start the stack (verify file names against the current README):
 
 ```bash
-docker compose \
-  -f docker-compose.ranger.yml \
-  -f docker-compose.ranger-hadoop.yml \
-  -f docker-compose.ranger-hive.yml \
-  -f docker-compose.ranger-ozone.yml \
-  build
-
 docker compose \
   -f docker-compose.ranger.yml \
   -f docker-compose.ranger-hadoop.yml \
@@ -79,120 +86,242 @@ docker compose \
   up -d
 ```
 
-### Option B: Assemble containers yourself
+Use `docker network inspect` to find the compose network name (often `rangernw`) and HMS hostname (often `ranger-hive`).
 
-Alternatively, run compatible images (for example [Apache Ranger](https://hub.docker.com/r/apache/ranger), [Apache Ozone](https://hub.docker.com/r/apache/ozone), and Hive/Hadoop images you trust) and attach them to **one user-defined Docker network** so Trino can resolve HMS and Ozone by container name.
+### Option B: Minimal lab without Ranger (Ozone + Hive Metastore)
+
+Verified against [Apache Ozone Docker](https://github.com/apache/ozone-docker) with `trinodb/trino:483` and `ozone-filesystem-hadoop3-2.2.0.jar`.
+
+1. Start Ozone with **three Datanodes** (recommended for writes; default replication needs healthy Ratis pipelines):
+
+   ```bash
+   git clone https://github.com/apache/ozone-docker.git
+   cd ozone-docker
+   docker compose -p ozone-trino up -d --scale datanode=3
+   ```
+
+   On a nearly full Docker disk, add smaller container defaults to compose (for example `ozone.scm.container.size: "1GB"` and `hdds.datanode.volume.min.free.space: "256MB"`) so SCM can allocate pipelines.
+
+2. Find the Docker network (example: `ozone-trino_default`):
+
+   ```bash
+   docker network ls | grep ozone-trino
+   ```
+
+3. Create an FSO bucket with **`RATIS/ONE`** replication (default `THREE` needs three Datanodes):
+
+   ```bash
+   docker compose -p ozone-trino exec om \
+     ozone sh bucket create s3v/trino-lab -l fso -t RATIS -r ONE
+   ```
+
+4. Prepare Hadoop/Ozone XML on the host (see [Hadoop and Ozone configuration](#hadoop-and-ozone-configuration-inside-trino)). HMS needs the **same** `core-site.xml`, `ozone-site.xml`, and Ozone JAR.
+
+5. Start Hive Metastore on the **same network**:
+
+   ```bash
+   docker run -d --name hive-metastore \
+     --network ozone-trino_default \
+     -p 9083:9083 \
+     -e SERVICE_NAME=metastore \
+     -v /path/to/hive-conf:/opt/hive/conf:ro \
+     -v /tmp/ozone-filesystem-hadoop3-2.2.0.jar:/opt/hive/lib/ozone-filesystem-hadoop3.jar:ro \
+     apache/hive:4.0.1
+   ```
+
+The `hive-conf` directory must include `hive-site.xml` (warehouse dir on Ozone), `core-site.xml`, and `ozone-site.xml`.
 
 :::warning Network and hostnames
-Trino’s catalog must use the **same Docker network** as HMS and the hosts named in `core-site.xml`. If Trino cannot resolve `ranger-hive` (or your HMS hostname), `thrift://` connections will fail. Replace example names with `docker network inspect` output from your stack.
+Trino’s catalog must use the **same Docker network** as HMS and the hostnames in `ozone-site.xml` / `core-site.xml` (for example `om`, `scm`). If Trino cannot resolve the HMS hostname, `thrift://` connections fail.
 :::
 
 ## 3. Run Trino and install the Ozone JAR
 
-Start a Trino container on the Ranger/Ozone network. The example uses image [trinodb/trino](https://hub.docker.com/r/trinodb/trino) and assumes the network is named `rangernw` (adjust to your setup):
+Start Trino on the Ozone/Hive network and bind-mount a host directory for Hadoop XML:
 
 ```bash
-docker run -d -p 8080:8080 --name trino --network rangernw trinodb/trino
+docker run -d -p 8080:8080 --name trino \
+  --network ozone-trino_default \
+  --memory=1536m \
+  -e JAVA_TOOL_OPTIONS="-Xmx768m -XX:+UseSerialGC" \
+  -v /path/to/hadoop-conf:/tmp/hadoop/conf:ro \
+  trinodb/trino
 ```
 
-Copy the Ozone filesystem JAR into the Hive HDFS plugin directory inside the container (paths match common Trino image layouts):
+With three Ozone Datanodes plus Hive Metastore, Trino may need a modest heap limit to avoid OOM on a typical Docker Desktop memory budget.
+
+Copy the Ozone filesystem JAR (and, if needed for Ozone 2.x + Trino 483, the Hadoop 3.4 interface supplemental JAR) into the Hive HDFS plugin directory:
 
 ```bash
-docker cp /tmp/ozone-filesystem-hadoop3-*.jar \
+docker cp /tmp/ozone-filesystem-hadoop3-2.2.0.jar \
   trino:/usr/lib/trino/plugin/hive/hdfs/
+# Lab only, if you see LeaseRecoverable errors:
+# docker cp /tmp/hadoop34-interfaces.jar trino:/usr/lib/trino/plugin/hive/hdfs/
+docker restart trino
 ```
 
-If your Trino image uses a different install root, locate `plugin/hive/hdfs` under that root.
+:::tip Docker Desktop on macOS
 
-The **`ozone-filesystem-hadoop3`** module normally produces a **self-contained (shaded) JAR** meant to be dropped in as a **single** file. If you see `NoClassDefFoundError` for Ozone or gRPC classes, you may have the wrong artifact or a partial copy—use the primary `ozone-filesystem-hadoop3-*.jar` from this module’s `target/` directory, or the matching artifact from Maven Central.
+- Use **`docker cp`** for catalog properties and JARs, or bind-mount a **directory** for `/etc/trino/catalog`—not individual property files (Docker may create a directory instead of a file).
+- Bind mounts under `/tmp` can appear empty inside the container; mount from a normal workspace path.
 
-**Restart Trino** after adding the JAR so the plugin class loader picks it up.
+:::
 
 ### Hadoop and Ozone configuration inside Trino
 
-`hive.config.resources` must point to **real files** inside the container (comma-separated list if you need more than one). Those files must define the Ozone filesystem (for example `fs.ofs.impl`) and OM/SCM addresses the same way your Hive/Hadoop stack does—usually by reusing `core-site.xml` (and sometimes additional config such as `ozone-site.xml` or keys merged into `core-site.xml`) from the Ranger/Hadoop/Ozone compose setup.
+`hive.config.resources` must list **separate** `core-site.xml` and `ozone-site.xml` files (comma-separated). Plain **`apache/ozone` Docker images** expose Ozone settings through environment variables; their packaged `core-site.xml` is often empty—author both files yourself.
 
-The doc does **not** copy those files for you. Typical approaches:
+**`core-site.xml`** (adjust hostnames to match compose service names):
 
-- **`docker cp`** from a Hadoop or edge container that already has the right XMLs, into a path such as `/tmp/hadoop/conf/`, or  
-- **`docker run -v`** to bind-mount a host directory of config into the Trino container.
+```xml
+<?xml version="1.0"?>
+<configuration>
+  <property>
+    <name>fs.ofs.impl</name>
+    <value>org.apache.hadoop.fs.ozone.RootedOzoneFileSystem</value>
+  </property>
+  <property>
+    <name>fs.AbstractFileSystem.ofs.impl</name>
+    <value>org.apache.hadoop.fs.ozone.RootedOzFs</value>
+  </property>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>ofs://om/</value>
+  </property>
+</configuration>
+```
 
-Until this matches your live Ozone cluster, Trino will fail when it tries to open `ofs://` paths even if the Hive catalog and Metastore connection work.
+**`ozone-site.xml`** (single OM on the `om` service):
 
-## 4. Hive catalog properties (`hive.properties`)
+```xml
+<?xml version="1.0"?>
+<configuration>
+  <property>
+    <name>ozone.om.address</name>
+    <value>om</value>
+  </property>
+  <property>
+    <name>ozone.om.service.ids</name>
+    <value>om</value>
+  </property>
+  <property>
+    <name>ozone.om.nodes.om</name>
+    <value>om</value>
+  </property>
+  <property>
+    <name>ozone.om.address.om.om</name>
+    <value>om</value>
+  </property>
+  <property>
+    <name>ozone.scm.names</name>
+    <value>scm</value>
+  </property>
+  <property>
+    <name>ozone.scm.client.address</name>
+    <value>scm</value>
+  </property>
+</configuration>
+```
 
-Create a catalog file for the Hive connector. The HMS URI and config paths **must match your deployment**.
+Mount these under `/tmp/hadoop/conf/` (or another path referenced from the catalog).
 
-Example `hive.properties`:
+## 4. Hive catalog properties (`ozone.properties`)
+
+The **file name** (without `.properties`) becomes the catalog name—for example `ozone.properties` → `SHOW CATALOGS` lists `ozone`.
+
+Example for the minimal lab:
 
 ```properties
 connector.name=hive
-hive.metastore.uri=thrift://ranger-hive:9083
+hive.metastore.uri=thrift://hive-metastore:9083
 fs.hadoop.enabled=true
-hive.config.resources=/tmp/hadoop/conf/core-site.xml
+hive.config.resources=/tmp/hadoop/conf/core-site.xml,/tmp/hadoop/conf/ozone-site.xml
 hive.non-managed-table-writes-enabled=true
-hive.hdfs.impersonation.enabled=true
+hive.hdfs.impersonation.enabled=false
+hive.dfs.replication=1
+hive.temporary-staging-directory-path=ofs://om/s3v/trino-lab/.staging
 ```
 
-Copy it into the container:
+Point **`hive.temporary-staging-directory-path`** at a bucket that uses **`RATIS/ONE`**. Trino otherwise stages under an auto-created `tmp` volume with default **`RATIS/THREE`**, which can fail when moving files into a one-replica lab bucket.
+
+Copy the catalog file and restart:
 
 ```bash
-docker cp hive.properties trino:/etc/trino/catalog/
+docker cp ozone.properties trino:/etc/trino/catalog/ozone.properties
+docker restart trino
 ```
 
-:::warning Possible configuration gaps
-- **`hive.config.resources`**: Must list real files inside the container (often you mount a host directory of Hadoop config at `/tmp/hadoop/conf` or another path you choose).
-- **`hive.hdfs.impersonation.enabled=true`**: Requires a secure setup where Trino can impersonate end users; in minimal Docker demos this can fail if Hadoop/Ozone security is not aligned with Trino. Disable or adjust only if you understand the security trade-offs.
-- **Managed vs external tables**: Behavior depends on HMS metadata and Ozone paths; see [Hive](./hive).
+:::warning Lab vs production settings
+
+- **`hive.hdfs.impersonation.enabled=false`** is for non-Kerberos labs only.
+- **`hive.config.resources`** must point to files that exist inside the container before the catalog starts.
+
 :::
 
-## 5. Ranger access control (`access-control.properties`)
+## 5. Ranger access control (optional)
 
-Ranger authorization for Trino depends on your **Trino version** and distribution: you need the Ranger access-control integration Trino expects (plugin JARs and native libraries, if any), **not** only the properties and XML files below. Follow [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html) end to end, including how to install Ranger’s Trino artifacts into the container image if required.
-
-If you enable Ranger for Trino, add an `access-control.properties` (location depends on Trino version; often `/etc/trino/`):
-
-```properties
-access-control.name=ranger
-ranger.service.name=dev_trino
-ranger.plugin.config.resource=/etc/trino/ranger-trino-security.xml,/etc/trino/ranger-trino-audit.xml,/etc/trino/ranger-policymgr-ssl.xml
-ranger.hadoop.config.resource=
-```
-
-Copy it in:
-
-```bash
-docker cp access-control.properties trino:/etc/trino/
-```
-
-You must also install the XML files referenced above (and any TLS trust stores or policy cache settings Ranger expects). Follow [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html) and your Ranger Admin deployment.
-
-:::warning Empty `ranger.hadoop.config.resource`
-The draft setup left **`ranger.hadoop.config.resource` blank**. That may be intentional for a minimal demo or it may be **incomplete** for your Ranger or Hadoop layout. Confirm with Trino and Ranger documentation whether Hadoop config must be passed to the Ranger plugin in your environment.
-:::
+Ranger requires the full Trino Ranger plugin install, not only property files. See [Trino Ranger access control](https://trino.io/docs/current/security/ranger-access-control.html).
 
 ## 6. Restart Trino and verify
 
-Restart the Trino container after configuration changes.
+After JAR, catalog, or XML changes, restart Trino. Then confirm connectivity and Ozone-backed DDL:
 
-1. Open the Trino web UI (port `8080` in the example) or use `trino-cli`.
-2. `SHOW CATALOGS` should list `hive` (or whatever you named the properties file without `.properties`).
-3. Run a simple query against a table you know is stored on Ozone (path visible in HMS).
+```sql
+SHOW CATALOGS;
+-- expect: ozone
+
+SHOW SCHEMAS FROM ozone;
+-- expect: default, information_schema, ...
+
+CREATE SCHEMA ozone.lab WITH (location = 'ofs://om/s3v/trino-lab/lab');
+
+CREATE TABLE ozone.lab.demo (
+  id bigint,
+  name varchar
+) WITH (format = 'PARQUET');
+
+INSERT INTO ozone.lab.demo VALUES (1, 'alice'), (2, 'bob');
+
+SELECT * FROM ozone.lab.demo ORDER BY id;
+```
+
+The following were **verified locally** with `ozone-filesystem-hadoop3-2.2.0.jar`, Ozone Docker **2.2.0** (three Datanodes), and Trino **483**:
+
+| Step | Result |
+| ---- | ------ |
+| `SHOW CATALOGS` / `SHOW SCHEMAS FROM ozone` | OK |
+| `CREATE SCHEMA ... WITH (location = 'ofs://...')` | OK |
+| `CREATE TABLE ... WITH (format = 'PARQUET')` | OK |
+| `INSERT` / `SELECT` with data | OK (with staging path and cluster notes below) |
+
+:::note Docker lab caveats
+
+- Scale compose with **`--scale datanode=3`**; default three-way replication needs three healthy Datanodes.
+- If writes hang, check SCM safe mode: `docker exec <scm> ozone admin safemode status` and `ozone admin safemode exit` if pipelines are slow to form.
+- On a nearly full Docker disk, lower **`ozone.scm.container.size`** (for example `1GB`) so SCM can allocate containers.
+- Set **`hive.temporary-staging-directory-path`** to a **`RATIS/ONE`** bucket path (see catalog example above).
+
+:::
 
 If initialization fails, check Trino logs for:
 
-- Class loading or **protobuf** errors (often an Ozone / Hadoop / Trino **version mismatch** or a wrong JAR on the plugin classpath).
-- **Metastore** connection errors (wrong host, port, or network).
-- **Filesystem** errors (missing `core-site.xml` properties for `ofs` / `o3fs`).
+- **`NoClassDefFoundError: LeaseRecoverable`**: See [Hadoop line compatibility](#ozone-jar-and-trino).
+- **`UnsupportedFileSystemException: No FileSystem for scheme "ofs"`**: Missing XML, wrong `hive.config.resources` paths, or HMS missing the Ozone JAR/config.
+- **Protobuf / class loading errors**: Ozone–Trino version skew; confirm you use **`ozone-filesystem-hadoop3`** only ([HDDS-14056](https://issues.apache.org/jira/browse/HDDS-14056)).
+- **Metastore errors**: Wrong HMS host, port, or network.
 
-## Summary of risks and open checks
+### Alternative: S3 Gateway (`s3a://`)
+
+If `ofs://` remains blocked by version skew, some deployments use Ozone’s **S3 Gateway** with Trino S3 settings. See [S3A](../01-client-interfaces/04-s3a) and [Trino discussion #18026](https://github.com/trinodb/trino/discussions/18026).
+
+## Summary
 
 | Area | What to verify |
 | ---- | -------------- |
-| Ozone JAR vs Trino | Use **`ozone-filesystem-hadoop3-*.jar`** from **`ozonefs-hadoop3`**; Ozone version and Hadoop line must match Trino and your cluster. |
-| Versions | Pinned Git commits and `*-SNAPSHOT` JARs are for **development**, not production baselines. |
-| Docker compose | File names and services come from the Ranger repo; they **drift** on `master`. |
-| Ranger | All `ranger-*.xml` files, service definitions, and `ranger.hadoop.config.resource` must match Ranger Admin and your Hadoop/Ozone config. |
-| Impersonation | `hive.hdfs.impersonation.enabled` requires a coherent security story across Trino, Hadoop, and Ozone. |
+| Ozone JAR | **`ozone-filesystem-hadoop3-*.jar`** only ([HDDS-14056](https://issues.apache.org/jira/browse/HDDS-14056)); match cluster version. |
+| Install path | Drop into Trino **`plugin/hive/hdfs/`**; same JAR on HMS classpath. |
+| Hadoop XML | **`fs.ofs.impl`**, **`fs.AbstractFileSystem.ofs.impl`**, OM/SCM in separate **`core-site.xml`** + **`ozone-site.xml`**. |
+| Trino + Ozone 2.x | Watch for Hadoop **3.3 vs 3.4** (`LeaseRecoverable`) on Trino 483. |
+| Docker lab | Same network; **`--scale datanode=3`**; **`RATIS/ONE`** buckets; staging path; exit SCM safe mode before writes. |
 
 For work tracked around this integration on the Ozone side, see [HDDS-12321](https://issues.apache.org/jira/browse/HDDS-12321).

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -233,7 +233,7 @@ function Integrations() {
           }}
         />
       ),
-      // link: '/docs/user-guide/integrations/trino'
+      link: "/docs/user-guide/integrations/trino",
     },
     {
       name: "Impala",


### PR DESCRIPTION
Use ozone-filesystem-hadoopF3 from the ozonefs-hadoop3 module (no ozonefs-hadoop3-client / proto.shaded.prefix). Clarify Hadoop XML and Ranger plugin requirements in-container.

Made-with: Cursor

## What changes were proposed in this pull request?

Document Trino with Ozone via the Hive connector, Ranger Docker-style workflows, ozonefs-hadoop3 JAR install, catalog and access-control properties, and operational caveats. Link Trino from the homepage.


## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-12321

## How was this patch tested?


<img width="1671" height="888" alt="Screenshot 2026-04-16 at 5 02 41 PM" src="https://github.com/user-attachments/assets/c627c48e-2c36-4d04-a8df-588127102026" />
