### PR TITLE
HDDS-15097. Link Cloudera Ozone EC benchmark (Teragen/Terasort)

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -125,6 +125,7 @@ words:
 - flekszible
 - TDE
 - Teragen
+- Terasort
 - TPC
 - RPC
 - aarch

--- a/docs/03-core-concepts/06-comparison.md
+++ b/docs/03-core-concepts/06-comparison.md
@@ -49,6 +49,10 @@ Ozone shines when users look for commodity hardware, open systems and embrace th
 
 These cloud storage offerings are only available from their respective public cloud vendors. In contrast, Ozone runs on-prem or in your private cloud, giving you full control.
 
+## Further reading (third-party benchmarks)
+
+For a **benchmark-driven** look at Ozone—**erasure-coded** data with **Teragen** and **Terasort** compared in the same style as classic HDFS workloads—see Cloudera’s write-up on Medium: [Cloudera Object Store EC performance evaluation (Teragen and Terasort)](https://medium.com/@ritesh_76398/cloudera-object-store-ec-performance-evaluation-by-benchmarking-with-teragen-and-terasort-c541af020237). It is an independent article, not Apache project documentation; use it alongside your own testing.
+
 ## Summary
 
 In summary, Ozone is the best fit in the following scenarios:


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-15097. Link Cloudera Ozone EC benchmark (Teragen/Terasort)

Please describe your PR in detail:
- Add third-party Medium article under Core Concepts > Comparison with Other Storage Technologies. Add Terasort to cspell dictionary.

Made-with: Cursor



## What is the link to the Apache Jira?
https://issues.apache.org/jira/browse/HDDS-15097

## How was this patch tested?

Please explain how this patch was tested. In most cases this will just be checking the local preview of the website, but existing CI checks should also pass.

