### PR TITLE
HDDS-9698. Skip push build for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ on:
   push:
     branches-ignore:
     - automated-config-doc-update
-    - 'dependabot/**'
+    - dependabot/**
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ on:
   push:
     branches-ignore:
     - automated-config-doc-update
+    - 'dependabot/**'
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,6 +17,9 @@ name: zizmor
 
 on:
   push:
+    branches-ignore:
+    - automated-config-doc-update
+    - 'dependabot/**'
   pull_request:
 
 permissions: { }

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,7 +19,7 @@ on:
   push:
     branches-ignore:
     - automated-config-doc-update
-    - 'dependabot/**'
+    - dependabot/**
   pull_request:
 
 permissions: { }


### PR DESCRIPTION
## What changes were proposed in this pull request?

dependabot pushes dependency version bumps to the main repo instead of its own fork.  It then creates a pull request without waiting for the `push` workflow to succeed.  Thus both workflows test the same state of code, which is unnecessary.

I propose completely skipping `push` build for dependabot's changes to save CI resources.

https://issues.apache.org/jira/browse/HDDS-9698

## How was this patch tested?

Similar setting already used in other Ozone repos.

https://github.com/adoroszlai/ozone-site/actions/runs/25040987578
https://github.com/adoroszlai/ozone-site/actions/runs/25040987590