### PR TITLE
HDDS-14663. [Docs] Fix broken link to configuration page on docker quick-start

### DIFF
--- a/docs/02-quick-start/01-installation/01-docker.md
+++ b/docs/02-quick-start/01-installation/01-docker.md
@@ -83,7 +83,7 @@ x-common-config:
   OZONE-SITE.XML_ozone.recon.http-address: 0.0.0.0:9090
 ```
 
-Refer to the [Configuring Ozone For Production](../../quick-start/installation/docker) page for more configuration guidelines.
+Refer to the [Configuring Ozone For Production](../../administrator-guide/configuration) page for more configuration guidelines.
 
 ## Next Steps
 

--- a/versioned_docs/version-2.1.0/02-quick-start/01-installation/01-docker.md
+++ b/versioned_docs/version-2.1.0/02-quick-start/01-installation/01-docker.md
@@ -83,7 +83,7 @@ x-common-config:
   OZONE-SITE.XML_ozone.recon.http-address: 0.0.0.0:9090
 ```
 
-Refer to the [Configuring Ozone For Production](../installation/docker) page for more configuration guidelines.
+Refer to the [Configuring Ozone For Production](../../administrator-guide/configuration) page for more configuration guidelines.
 
 ## Next Steps
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The "Configuring Ozone For Production" link on the Docker quick-start page pointed back to the docker page itself. This fixes it to point to the Administrator Guide → Configuration page.

The same fix is applied to `versioned_docs/version-2.1.0/` so users on the current released version (the default `/docs/...` route) also see the working link. Per `CONTRIBUTING.md`, `versioned_docs/` is updated only to backport fixes — which this is.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-14663

## How was this patch tested?

Verified locally with `pnpm start`:
- `/docs/quick-start/installation/docker` (versioned 2.1.0)
- `/docs/next/quick-start/installation/docker` (working copy)

The "Configuring Ozone For Production" link on both now navigates to the Configuration overview page.


https://github.com/user-attachments/assets/29287861-bdbe-404a-bd6a-7604a94c4187
