### PR TITLE
HDDS-14980. Fix broken links in "Who Uses Ozone?" page.

### DIFF
--- a/blog/2026-01-30-apache-ozone-best-practices-at-didi.md
+++ b/blog/2026-01-30-apache-ozone-best-practices-at-didi.md
@@ -5,7 +5,7 @@ authors: ["rich7420", "apache-ozone-community", "slfan1989", "whbing", "jianghua
 tags: [user-stories, performance, erasure-coding, scale]
 ---
 
-Guest post by the Didi Engineering Team. For the full story with detailed slides, see [Apache Ozone Best Practices at Didi (PDF)](https://ozone.apache.org/assets/ApacheOzoneBestPracticesAtDidi.pdf).
+Guest post by the Didi Engineering Team. For the full story with detailed slides, see [Apache Ozone Best Practices at Didi (PDF)](/ApacheOzoneBestPracticesAtDidi.pdf).
 
 As Didi's volume of unstructured data surged into the hundreds of petabytes, comprising tens of billions of files, their traditional storage architecture faced severe scalability bottlenecks. This post summarizes how they migrated from HDFS to Apache Ozone, the optimizations they implemented for high-performance reads, and their journey in contributing these improvements back to the community.
 

--- a/src/pages/community/who-uses-ozone.md
+++ b/src/pages/community/who-uses-ozone.md
@@ -6,10 +6,10 @@ This page lists organizations that are using Apache Ozone in production or for s
 |--------------|---------------------------------------------------------|
 | Tencent      | Data warehouses, Machine Learning Platforms etc: [Tencent Cloud Article](https://cloud.tencent.com/developer/article/1667033) |
 | Cloudera     |                                                         |
-| Shopee       | Practices of Ozone at Shopee: [Google Drive Link](https://drive.google.com/file/d/1vrUy9K6PlAnNhlaZVJ-6q6cKJIi1QFXA/view) |
+| Shopee       | Practices of Ozone at Shopee: [Apache Ozone Best Practices at Shopee (PDF)](/ApacheOzoneBestPracticesAtShopee.pdf) |
 | Preferred Networks | ML Cluster: [A Year with Apache Ozone](https://tech.preferred.jp/en/blog/a-year-with-apache-ozone/), [Two Years with Apache Ozone](https://tech.preferred.jp/en/blog/two-years-with-apache-ozone/) |
 | G-Research   | [G-Research Open-Source](https://opensource.gresearch.co.uk/) |
 | Qihoo360     | [WeChat Article](https://mp.weixin.qq.com/s/OB_YTlXfDMg6ZfMaYOkn_Q) |
-| DiDi         | [Apache Ozone Best Practices at DiDi (PDF)](https://ozone.apache.org/assets/ApacheOzoneBestPracticesAtDidi.pdf) |
+| DiDi         | [Apache Ozone Best Practices at DiDi (PDF)](/ApacheOzoneBestPracticesAtDidi.pdf) |
 | Meituan      |                                                         |
 | China Unicom |                                                         |


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes the two broken links on https://ozone.apache.org/community/who-uses-ozone/ reported in [HDDS-14980](https://issues.apache.org/jira/browse/HDDS-14980):

- **Shopee** — the Google Drive link was not publicly accessible. Repointed to the existing static asset `/ApacheOzoneBestPracticesAtShopee.pdf` already committed under `static/` (the same deck is linked from `events-and-media.md`).
- **DiDi** — the previous URL `https://ozone.apache.org/assets/ApacheOzoneBestPracticesAtDidi.pdf` returned 404 (no such path is served). Committed the PDF to `static/ApacheOzoneBestPracticesAtDidi.pdf` and updated the link to `/ApacheOzoneBestPracticesAtDidi.pdf`.
- The same broken DiDi URL also appeared in `blog/2026-01-30-apache-ozone-best-practices-at-didi.md` and has been updated to the new path.

## What is the link to the Apache JIRA?

https://issues.apache.org/jira/browse/HDDS-14980

## How was this patch tested?

Verified locally with the Docusaurus dev server (`pnpm start`):

https://github.com/user-attachments/assets/6f505ad1-285b-426b-9f73-135f3502f989
