### PR TITLE
HDDS-15226. [Docs] Link to Code Wiki under Developer Guide.

### DIFF
--- a/docs/08-developer-guide/04-project/03-javadoc.md
+++ b/docs/08-developer-guide/04-project/03-javadoc.md
@@ -1,13 +1,26 @@
 ---
-sidebar_label: JavaDoc
+sidebar_label: Code References
 ---
 
-# Ozone JavaDoc API
+# Ozone Code References
 
-You can find the latest Ozone JavaDoc at the following URL:
+This page lists references that help you read and navigate the Apache
+Ozone source code.
 
-[Ozone JavaDoc API](https://javadoc.io/doc/org.apache.ozone)
+## JavaDoc
+
+The latest Ozone JavaDoc is published at
+[javadoc.io](https://javadoc.io/doc/org.apache.ozone).
 
 :::note
-The Javadoc is available for version 2.1.0 and later.
+The JavaDoc is available for version 2.1.0 and later.
 :::
+
+## Code Wiki
+
+[Code Wiki](https://codewiki.google/github.com/apache/ozone) is an
+independent, AI-generated reference for the `apache/ozone` source tree,
+not produced by the Apache Ozone project. It provides summaries of
+packages and classes that can complement the JavaDoc when exploring
+unfamiliar parts of the codebase; always confirm important details
+against the source code.


### PR DESCRIPTION
## What changes were proposed?

Adds a link to [Code Wiki](https://codewiki.google/github.com/apache/ozone) — an AI-generated code reference — to the existing JavaDoc page under *Developer Guide → Project*.

Since the page now lists multiple tools, the sidebar label and H1 are generalized:

- `sidebar_label`: `JavaDoc` → `Code References`
- H1: `Ozone JavaDoc API` → `Ozone Code References`
- JavaDoc and Code Wiki are now `##` sub-sections.

The filename (and URL slug `…/javadoc`) is intentionally unchanged — see the inline comment for the rationale and the plan to revisit it.

## Jira

https://issues.apache.org/jira/browse/HDDS-15226

## How was this patch tested?

- `npx cspell` and `npx markdownlint` on the changed file — clean.
- `npm run build` — passes (with `onBrokenLinks: 'throw'`).
- `npm run start` — verified at `http://localhost:3001/docs/next/developer-guide/project/javadoc`: sidebar shows "Code References" in the third Project slot, both external links resolve.

<img width="1512" height="873" alt="Screenshot 2026-05-18 at 9 40 54 PM" src="https://github.com/user-attachments/assets/870e1c23-944d-4765-a772-110256be9516" />
