### PR TITLE
HDDS-15343. Restore .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,19 +18,19 @@ meta:
   nextgen: true
 
 github:
-  description: "Website for Apache Ozone"
+  description: Website for Apache Ozone
   homepage: https://ozone.apache.org/
   labels:
-    - ozone
+  - ozone
   enabled_merge_buttons:
-    squash:  true
+    squash: true
     squash_commit_message: PR_TITLE
-    merge:   false
-    rebase:  false
+    merge: false
+    rebase: false
   autolink_jira:
-    - HDDS
+  - HDDS
 notifications:
-  commits:      commits@ozone.apache.org
-  issues:       issues@ozone.apache.org
+  commits: commits@ozone.apache.org
+  issues: issues@ozone.apache.org
   pullrequests: issues@ozone.apache.org
   jira_options: link label

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enable the next-gen .asf.yaml parser
+meta:
+  nextgen: true
+
+github:
+  description: "Website for Apache Ozone"
+  homepage: https://ozone.apache.org/
+  labels:
+    - ozone
+  enabled_merge_buttons:
+    squash:  true
+    squash_commit_message: PR_TITLE
+    merge:   false
+    rebase:  false
+  autolink_jira:
+    - HDDS
+notifications:
+  commits:      commits@ozone.apache.org
+  issues:       issues@ozone.apache.org
+  pullrequests: issues@ozone.apache.org
+  jira_options: link label


### PR DESCRIPTION
## What changes were proposed in this pull request?

Restore `.asf.yaml`, removed by HDDS-9561 along with old website content.

https://issues.apache.org/jira/browse/HDDS-15343

## How was this patch tested?

https://github.com/adoroszlai/ozone-site/actions/runs/26230250657