### PR TITLE
HDDS-9571. Enable Docusaurus i18n support

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,7 +52,19 @@ const config = {
   // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
-    locales: ['en'],
+    locales: ['en', 'zh-Hans'],
+    localeConfigs: {
+      en: {
+        label: 'English',
+        direction: 'ltr',
+        htmlLang: 'en-US',
+      },
+      'zh-Hans': {
+        label: '简体中文',
+        direction: 'ltr',
+        htmlLang: 'zh-Hans',
+      },
+    },
   },
 
   /*

--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -1,0 +1,444 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "页面已崩溃。",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.blog.archive.title": {
+    "message": "历史博文",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "历史博文",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "回到顶部",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "博文列表分页导航",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "较新的博文",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "较旧的博文",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "博文分页导航",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "较新一篇",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "较旧一篇",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "查看所有标签",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "切换浅色/暗黑模式（当前为{mode}）",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "暗黑模式",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "浅色模式",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "{count} 个项目",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "页面路径",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "文件选项卡",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "上一页",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "下一页",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "{count} 篇文档带有标签",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged}「{tagName}」",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "版本：{versionLabel}"
+  },
+  "theme.common.editThisPage": {
+    "message": "编辑此页",
+    "description": "The link label to edit the current page"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "此为 {siteTitle} {versionLabel} 版尚未发行的文档。",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "此为 {siteTitle} {versionLabel} 版的文档，现已不再积极维护。",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "最新的文档请参阅 {latestVersionLink} ({versionLabel})。",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "最新版本",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "{heading}的直接链接",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": "于 {date} ",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": "由 {user} ",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "最后{byUser}{atDate}更新",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "选择版本",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "找不到页面",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "标签：",
+    "description": "The label alongside a tag list"
+  },
+  "theme.admonition.caution": {
+    "message": "警告",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "危险",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "信息",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "备注",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "提示",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "注意",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "关闭",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "最近博文导航",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "复制成功",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "复制代码到剪贴板",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "复制",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "切换自动换行",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "展开侧边栏分类 '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "折叠侧边栏分类 '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "主导航",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.NotFound.p1": {
+    "message": "我们找不到您要找的页面。",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "请联系原始链接来源网站的所有者，并告知他们链接已损坏。",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "本页总览",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "选择语言",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "阅读需 {readingTime} 分钟",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "主页面",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "收起侧边栏",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.blog.post.readMore": {
+    "message": "阅读更多",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "阅读 {title} 的全文",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "文档侧边栏",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "关闭导航栏",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← 回到主菜单",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "切换导航栏",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "展开侧边栏",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "查看全部 {count} 个结果"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "找到 {count} 份文件",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "「{query}」的搜索结果",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "在文档中搜索",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "在此输入搜索字词",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "搜索",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "通过 Algolia 搜索",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "未找到任何结果",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "正在获取新的搜索结果...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchBar.label": {
+    "message": "搜索",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "清除查询",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "取消",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "最近搜索",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "没有最近搜索",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "保存这个搜索",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "从历史记录中删除这个搜索",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "收藏",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "从收藏列表中删除这个搜索",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "无法获取结果",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "你可能需要检查网络连接。",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "选中",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter 键",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "导航",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "向上键",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "向下键",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "关闭",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Esc 键",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "搜索提供",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "没有结果：",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "试试搜索",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "认为这个查询应该有结果？",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "请告知我们。",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "搜索文档",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count} 篇博文",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} 含有标签「{tagName}」",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "作者",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "查看所有作者",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "该作者还没有发布任何文章。",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "未列出页",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "此页面未列出。搜索引擎不会对其索引，只有拥有直接链接的用户才能访问。",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "草稿页面",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "此页面是草稿。它只会在开发环境中可见，并会从生产构建中排除。",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "重试",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "跳到主要内容",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "标签",
+    "description": "The title of the tag list page"
+  }
+}

--- a/i18n/zh-Hans/docusaurus-plugin-content-blog/options.json
+++ b/i18n/zh-Hans/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "博客",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "博客",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "近期文章",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,242 @@
+{
+  "version.label": {
+    "message": "下一版",
+    "description": "The label for version current"
+  },
+  "sidebar.defaultSidebar.category.Quick Start": {
+    "message": "快速开始",
+    "description": "The label for category Quick Start in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Installation": {
+    "message": "安装",
+    "description": "The label for category Installation in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Core Concepts": {
+    "message": "核心概念",
+    "description": "The label for category Core Concepts in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Architecture": {
+    "message": "架构",
+    "description": "The label for category Architecture in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Replication": {
+    "message": "复制",
+    "description": "The label for category Replication in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Namespace": {
+    "message": "命名空间",
+    "description": "The label for category Namespace in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Volumes": {
+    "message": "卷",
+    "description": "The label for category Volumes in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Buckets": {
+    "message": "桶",
+    "description": "The label for category Buckets in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Layouts": {
+    "message": "布局",
+    "description": "The label for category Layouts in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Keys": {
+    "message": "键",
+    "description": "The label for category Keys in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Security": {
+    "message": "安全",
+    "description": "The label for category Security in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.ACLs": {
+    "message": "ACL",
+    "description": "The label for category ACLs in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.High Availability": {
+    "message": "高可用",
+    "description": "The label for category High Availability in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.User Guide": {
+    "message": "用户指南",
+    "description": "The label for category User Guide in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Client Interfaces": {
+    "message": "客户端接口",
+    "description": "The label for category Client Interfaces in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.S3 API": {
+    "message": "S3 API",
+    "description": "The label for category S3 API in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Clients": {
+    "message": "客户端",
+    "description": "The label for category Clients in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Integrations": {
+    "message": "集成",
+    "description": "The label for category Integrations in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Administrator Guide": {
+    "message": "管理员指南",
+    "description": "The label for category Administrator Guide in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Configuration": {
+    "message": "配置",
+    "description": "The label for category Configuration in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Basic": {
+    "message": "基础",
+    "description": "The label for category Basic in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Network": {
+    "message": "网络",
+    "description": "The label for category Network in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Directories": {
+    "message": "目录",
+    "description": "The label for category Directories in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Logging": {
+    "message": "日志",
+    "description": "The label for category Logging in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Encryption": {
+    "message": "加密",
+    "description": "The label for category Encryption in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Network Encryption": {
+    "message": "网络加密",
+    "description": "The label for category Network Encryption in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Performance": {
+    "message": "性能",
+    "description": "The label for category Performance in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Operations": {
+    "message": "运维",
+    "description": "The label for category Operations in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Decommissioning and Maintenance": {
+    "message": "退役与维护",
+    "description": "The label for category Decommissioning and Maintenance in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Datanode": {
+    "message": "Datanode",
+    "description": "The label for category Datanode in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Disk Replacement": {
+    "message": "磁盘更换",
+    "description": "The label for category Disk Replacement in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Data Balancing": {
+    "message": "数据均衡",
+    "description": "The label for category Data Balancing in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.S3 Multi-Tenancy": {
+    "message": "S3 多租户",
+    "description": "The label for category S3 Multi-Tenancy in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Snapshots": {
+    "message": "快照",
+    "description": "The label for category Snapshots in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Observability": {
+    "message": "可观测性",
+    "description": "The label for category Observability in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Recon": {
+    "message": "Recon",
+    "description": "The label for category Recon in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Leader Transfer": {
+    "message": "Leader 转移",
+    "description": "The label for category Leader Transfer in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Tools": {
+    "message": "工具",
+    "description": "The label for category Tools in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Ozone Debug": {
+    "message": "Ozone 调试",
+    "description": "The label for category Ozone Debug in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Troubleshooting": {
+    "message": "故障排查",
+    "description": "The label for category Troubleshooting in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.System Internals": {
+    "message": "系统内部原理",
+    "description": "The label for category System Internals in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Components": {
+    "message": "组件",
+    "description": "The label for category Components in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Ozone Manager": {
+    "message": "Ozone Manager",
+    "description": "The label for category Ozone Manager in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Storage Container Manager": {
+    "message": "Storage Container Manager",
+    "description": "The label for category Storage Container Manager in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.S3 Gateway": {
+    "message": "S3 Gateway",
+    "description": "The label for category S3 Gateway in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Client": {
+    "message": "客户端",
+    "description": "The label for category Client in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.HttpFS Gateway": {
+    "message": "HttpFS Gateway",
+    "description": "The label for category HttpFS Gateway in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Data Operations": {
+    "message": "数据操作",
+    "description": "The label for category Data Operations in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Data Integrity": {
+    "message": "数据完整性",
+    "description": "The label for category Data Integrity in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Data": {
+    "message": "数据",
+    "description": "The label for category Data in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Write Pipelines": {
+    "message": "写入管道",
+    "description": "The label for category Write Pipelines in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Containers": {
+    "message": "容器",
+    "description": "The label for category Containers in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Network Protocols": {
+    "message": "网络协议",
+    "description": "The label for category Network Protocols in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Features": {
+    "message": "特性",
+    "description": "The label for category Features in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Developer Guide": {
+    "message": "开发者指南",
+    "description": "The label for category Developer Guide in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Build": {
+    "message": "构建",
+    "description": "The label for category Build in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Run": {
+    "message": "运行",
+    "description": "The label for category Run in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Test": {
+    "message": "测试",
+    "description": "The label for category Test in sidebar defaultSidebar"
+  },
+  "sidebar.defaultSidebar.category.Project": {
+    "message": "项目",
+    "description": "The label for category Project in sidebar defaultSidebar"
+  }
+}

--- a/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -1,0 +1,86 @@
+{
+  "link.title.Apache Software Foundation": {
+    "message": "Apache Software Foundation",
+    "description": "The title of the footer links column with title=Apache Software Foundation in the footer"
+  },
+  "link.title.Community": {
+    "message": "社区",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.Repositories": {
+    "message": "代码仓库",
+    "description": "The title of the footer links column with title=Repositories in the footer"
+  },
+  "link.item.label.Foundation": {
+    "message": "基金会",
+    "description": "The label of footer link with label=Foundation linking to https://www.apache.org/"
+  },
+  "link.item.label.License": {
+    "message": "许可证",
+    "description": "The label of footer link with label=License linking to https://www.apache.org/licenses/"
+  },
+  "link.item.label.Events": {
+    "message": "活动",
+    "description": "The label of footer link with label=Events linking to https://www.apache.org/events/current-event"
+  },
+  "link.item.label.Sponsorship": {
+    "message": "赞助",
+    "description": "The label of footer link with label=Sponsorship linking to https://www.apache.org/foundation/sponsorship.html"
+  },
+  "link.item.label.Privacy": {
+    "message": "隐私",
+    "description": "The label of footer link with label=Privacy linking to https://privacy.apache.org/policies/privacy-policy-public.html"
+  },
+  "link.item.label.Security": {
+    "message": "安全",
+    "description": "The label of footer link with label=Security linking to https://www.apache.org/security/"
+  },
+  "link.item.label.Thanks": {
+    "message": "致谢",
+    "description": "The label of footer link with label=Thanks linking to https://www.apache.org/foundation/thanks.html"
+  },
+  "link.item.label.GitHub Discussions": {
+    "message": "GitHub 讨论",
+    "description": "The label of footer link with label=GitHub Discussions linking to https://github.com/apache/ozone/discussions"
+  },
+  "link.item.label.Jira Issues": {
+    "message": "Jira 问题",
+    "description": "The label of footer link with label=Jira Issues linking to https://issues.apache.org/jira/projects/HDDS/issues"
+  },
+  "link.item.label.Slack": {
+    "message": "Slack",
+    "description": "The label of footer link with label=Slack linking to https://infra.apache.org/slack.html"
+  },
+  "link.item.label.Mailing List": {
+    "message": "邮件列表",
+    "description": "The label of footer link with label=Mailing List linking to mailto:dev@ozone.apache.org"
+  },
+  "link.item.label.YouTube": {
+    "message": "YouTube",
+    "description": "The label of footer link with label=YouTube linking to https://www.youtube.com/@ApacheOzone"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/ApacheOzone"
+  },
+  "link.item.label.Ozone": {
+    "message": "Ozone",
+    "description": "The label of footer link with label=Ozone linking to https://github.com/apache/ozone"
+  },
+  "link.item.label.Website": {
+    "message": "网站",
+    "description": "The label of footer link with label=Website linking to https://github.com/apache/ozone-site"
+  },
+  "link.item.label.Docker Image": {
+    "message": "Docker 镜像",
+    "description": "The label of footer link with label=Docker Image linking to https://github.com/apache/ozone-docker"
+  },
+  "link.item.label.Docker Runner Image": {
+    "message": "Docker Runner 镜像",
+    "description": "The label of footer link with label=Docker Runner Image linking to https://github.com/apache/ozone-docker-runner"
+  },
+  "copyright": {
+    "message": "\n        <div>\n          Copyright © 2026 <a href=\"https://www.apache.org/\" class=copyright-link>The Apache Software Foundation</a>. Licensed under the <a href=\"https://www.apache.org/licenses/LICENSE-2.0\" class=copyright-link>Apache License, Version 2.0</a>. <br>\n          <div>\n            <p>The Apache Software Foundation, Apache Ozone, Ozone, Apache, the Apache Feather, and the Apache Ozone project logo are either registered trademarks or trademarks of the Apache Software Foundation.</p>\n          </div>\n        </div>",
+    "description": "The footer copyright"
+  }
+}

--- a/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,58 @@
+{
+  "title": {
+    "message": "Apache Ozone",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "Ozone 标志",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Docs": {
+    "message": "文档",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Download": {
+    "message": "下载",
+    "description": "Navbar item with label Download"
+  },
+  "item.label.Roadmap": {
+    "message": "路线图",
+    "description": "Navbar item with label Roadmap"
+  },
+  "item.label.FAQ": {
+    "message": "常见问题",
+    "description": "Navbar item with label FAQ"
+  },
+  "item.label.Blog": {
+    "message": "博客",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.Community": {
+    "message": "社区",
+    "description": "Navbar item with label Community"
+  },
+  "item.label.Communication Channels": {
+    "message": "沟通渠道",
+    "description": "Navbar item with label Communication Channels"
+  },
+  "item.label.Who Uses Ozone?": {
+    "message": "谁在使用 Ozone？",
+    "description": "Navbar item with label Who Uses Ozone?"
+  },
+  "item.label.Report An Issue": {
+    "message": "报告问题",
+    "description": "Navbar item with label Report An Issue"
+  },
+  "item.label.Ask a Question": {
+    "message": "提出问题",
+    "description": "Navbar item with label Ask a Question"
+  },
+  "item.label.How to Contribute": {
+    "message": "如何贡献",
+    "description": "Navbar item with label How to Contribute"
+  },
+  "item.label.Events and Media": {
+    "message": "活动与媒体",
+    "description": "Navbar item with label Events and Media"
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-9571. Enable Docusaurus i18n support

This pull request enables Docusaurus internationalization support for Simplified Chinese on the Apache Ozone Website v2 branch.
The patch adds `zh-Hans` to the Docusaurus locale configuration, defines locale metadata for English and Simplified Chinese, and generates the initial Docusaurus translation scaffold under `i18n/zh-Hans`. It also provides initial Simplified Chinese translations for core website UI labels, including the navbar, footer, blog options, built-in theme strings, and documentation sidebar category labels.

The goal is to enable the Website v2 i18n framework so the site can expose Chinese locale routes such as `/zh-Hans/`. This patch does not attempt to translate every Markdown or MDX content page. Full Chinese documentation translation or migration can be handled incrementally in follow-up patches.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-9571

## How was this patch tested?

The patch was tested with the following commands:

```bash
pnpm clear
.github/scripts/markdownlint.sh
.github/scripts/file_names.sh
.github/scripts/sidebar.sh
.github/scripts/spelling.sh
pnpm build