### PR TITLE
HDDS-15358. Update environment variable docs to match shell script behavior

### DIFF
--- a/docs/05-administrator-guide/02-configuration/01-basic/02-environment-variables.md
+++ b/docs/05-administrator-guide/02-configuration/01-basic/02-environment-variables.md
@@ -20,6 +20,7 @@ These environment variables apply to all Ozone processes.
 | `OZONE_LOG_DIR`    | `$OZONE_HOME/logs`                 | The directory where Ozone log files are stored.                                                                   |
 | `OZONE_PID_DIR`    | `/tmp`                             | The directory where daemon PID files are stored.                                                                  |
 | `OZONE_OPTS`       | `-Djava.net.preferIPv4Stack=true`  | Universal Java options applied to all Ozone processes.                                                            |
+| `OZONE_LOGLEVEL`   | `INFO`                             | The default log level applied to Ozone processes.                                                                |
 | `OZONE_HEAPSIZE_MAX`| (JVM default)                      | The maximum JVM heap size (`-Xmx`). If not set, the JVM auto-scales.                                              |
 | `OZONE_HEAPSIZE_MIN`| (JVM default)                      | The minimum JVM heap size (`-Xms`). If not set, the JVM auto-scales.                                              |
 
@@ -36,9 +37,16 @@ These environment variables apply only to certain Ozone services or roles.
 | `OZONE_DATANODE_OPTS`| (empty)                            | Specifies Java properties for Datanodes.                                                                          |
 | `OZONE_S3G_OPTS`   | (empty)                            | Specifies Java properties for the S3 Gateway.                                                                     |
 | `OZONE_RECON_OPTS` | (empty)                            | Specifies Java properties for the Recon server.                                                                   |
+| `OZONE_HTTPFS_OPTS`| (empty)                            | Specifies Java properties for the HttpFS Gateway.                                                                 |
+| `OZONE_CSI_OPTS`   | (empty)                            | Specifies Java properties for the CSI server.                                                                     |
+| `OZONE_SH_OPTS`    | (empty)                            | Specifies Java properties for the `ozone sh` command.                                                             |
+| `OZONE_FS_OPTS`    | (empty)                            | Specifies Java properties for the `ozone fs` command.                                                             |
+| `OZONE_ADMIN_OPTS` | (empty)                            | Specifies Java properties for the `ozone admin` command.                                                          |
+| `OZONE_DEBUG_OPTS` | (empty)                            | Specifies Java properties for the `ozone debug` command.                                                          |
+| `OZONE_FREON_OPTS` | (empty)                            | Specifies Java properties for the `ozone freon` command.                                                          |
 
 :::note HttpFS Gateway Configuration
-The HttpFS Gateway does not use an `OZONE_HTTPFS_OPTS` variable. Its specific JVM properties must be added to the global `OZONE_OPTS` variable.
+The HttpFS Gateway supports a dedicated `OZONE_HTTPFS_OPTS` variable, just like the other daemons. Any JVM properties set in `OZONE_HTTPFS_OPTS` are folded into `OZONE_OPTS` when the gateway starts, so you no longer need to add them to the global `OZONE_OPTS` variable.
 :::
 
 ## Configuration Methods

--- a/docs/05-administrator-guide/02-configuration/01-basic/02-environment-variables.md
+++ b/docs/05-administrator-guide/02-configuration/01-basic/02-environment-variables.md
@@ -49,10 +49,6 @@ These environment variables apply only to certain Ozone services or roles.
 | `OZONE_VAPOR_OPTS` | (empty)                            | Specifies Java properties for the `ozone vapor` command.                                                          |
 | `OZONE_DAEMON_JSVC_EXTRA_OPTS`| (none)                  | Extra arguments passed to `jsvc` when launching secure (privileged) daemons.                                     |
 
-:::note HttpFS Gateway Configuration
-The HttpFS Gateway supports a dedicated `OZONE_HTTPFS_OPTS` variable, just like the other daemons. Any JVM properties set in `OZONE_HTTPFS_OPTS` are folded into `OZONE_OPTS` when the gateway starts, so you no longer need to add them to the global `OZONE_OPTS` variable.
-:::
-
 ## Configuration Methods
 
 There are several ways to set these environment variables, depending on your needs.

--- a/docs/05-administrator-guide/02-configuration/01-basic/02-environment-variables.md
+++ b/docs/05-administrator-guide/02-configuration/01-basic/02-environment-variables.md
@@ -18,7 +18,9 @@ These environment variables apply to all Ozone processes.
 | `OZONE_HOME`       | Auto-detected from script location | The path to the Ozone installation directory.                                                                     |
 | `OZONE_CONF_DIR`   | `$OZONE_HOME/etc/hadoop`           | The directory containing Ozone configuration files.                                                               |
 | `OZONE_LOG_DIR`    | `$OZONE_HOME/logs`                 | The directory where Ozone log files are stored.                                                                   |
+| `OZONE_SECURE_LOG_DIR`| `$OZONE_LOG_DIR`                | The directory where logs for secure (privileged) daemons are stored.                                              |
 | `OZONE_PID_DIR`    | `/tmp`                             | The directory where daemon PID files are stored.                                                                  |
+| `OZONE_WORKER_NAMES`| (none)                            | A space-separated list of worker host names, used as an alternative to the `OZONE_WORKERS` file. Only one of the two may be set. |
 | `OZONE_OPTS`       | `-Djava.net.preferIPv4Stack=true`  | Universal Java options applied to all Ozone processes.                                                            |
 | `OZONE_LOGLEVEL`   | `INFO`                             | The default log level applied to Ozone processes.                                                                |
 | `OZONE_HEAPSIZE_MAX`| (JVM default)                      | The maximum JVM heap size (`-Xmx`). If not set, the JVM auto-scales.                                              |
@@ -44,6 +46,8 @@ These environment variables apply only to certain Ozone services or roles.
 | `OZONE_ADMIN_OPTS` | (empty)                            | Specifies Java properties for the `ozone admin` command.                                                          |
 | `OZONE_DEBUG_OPTS` | (empty)                            | Specifies Java properties for the `ozone debug` command.                                                          |
 | `OZONE_FREON_OPTS` | (empty)                            | Specifies Java properties for the `ozone freon` command.                                                          |
+| `OZONE_VAPOR_OPTS` | (empty)                            | Specifies Java properties for the `ozone vapor` command.                                                          |
+| `OZONE_DAEMON_JSVC_EXTRA_OPTS`| (none)                  | Extra arguments passed to `jsvc` when launching secure (privileged) daemons.                                     |
 
 :::note HttpFS Gateway Configuration
 The HttpFS Gateway supports a dedicated `OZONE_HTTPFS_OPTS` variable, just like the other daemons. Any JVM properties set in `OZONE_HTTPFS_OPTS` are folded into `OZONE_OPTS` when the gateway starts, so you no longer need to add them to the global `OZONE_OPTS` variable.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is the website companion to HDDS-14443 (apache/ozone#10352), which fixed the in-distribution docs (`ozone-env.sh`) and the `ozone` launcher script in the apache/ozone repo. The website hosts a separate, hand-maintained copy of the same environment variable information that still carried the old inconsistencies. This PR updates `docs/.../02-environment-variables.md` so it matches the actual behavior of the shell scripts, brought to full parity with the variables defined in apache/ozone#10352.

**Role-Specific Environment Variables table** (added the missing rows):
- `OZONE_HTTPFS_OPTS`, `OZONE_CSI_OPTS` (daemon JVM opts)
- `OZONE_SH_OPTS`, `OZONE_FS_OPTS`, `OZONE_ADMIN_OPTS`, `OZONE_DEBUG_OPTS`, `OZONE_FREON_OPTS`, `OZONE_VAPOR_OPTS` (client/tool JVM opts)
- `OZONE_DAEMON_JSVC_EXTRA_OPTS` (extra arguments passed to `jsvc` when launching secure/privileged daemons)

**Common Environment Variables table** (added for parity):
- `OZONE_LOGLEVEL` (default `INFO`)
- `OZONE_SECURE_LOG_DIR` (default `$OZONE_LOG_DIR`)
- `OZONE_WORKER_NAMES`

**HttpFS Gateway admonition:** the `:::note` previously stated that HttpFS has no dedicated opts variable and that its JVM properties must be added to the global `OZONE_OPTS`. That is no longer true. The note now states that `OZONE_HTTPFS_OPTS` is supported and behaves like the other daemons (the generic `ozone_subcommand_opts` handler folds `OZONE_<SUBCMD>_OPTS` into `OZONE_OPTS`).

No reference to the non-functional `OZONE_SECURE_LOG` variable exists on this page (the scripts read `OZONE_SECURE_LOG_DIR`), so no change was needed there. The frozen released snapshot under `versioned_docs/version-2.1.0/` was intentionally not modified.

> ⚠️ **Merge order:** This documentation change describes behavior introduced by apache/ozone#10352. It should be merged **only after** apache/ozone#10352 has merged, otherwise the website would document variables that are not yet in any released/shipped script.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-15358

Follow-up to HDDS-14443 (apache/ozone#10352).

## How was this patch tested?

- `pnpm build` completed successfully (Server, Client, and Service Worker all compiled without errors).
- Verified the local preview renders the updated table rows and the rewritten HttpFS admonition at `/docs/next/administrator-guide/configuration/basic/environment-variables`.

<img width="1094" height="930" alt="Screenshot 2026-05-24 at 12 37 16 PM" src="https://github.com/user-attachments/assets/bbbe20a1-c2ce-480e-8958-81035e243198" />

<img width="1142" height="1225" alt="Screenshot 2026-05-24 at 12 37 22 PM" src="https://github.com/user-attachments/assets/06de5695-d493-474e-a49e-3044d9baf013" />

