### PR TITLE
HDDS-15373. [Docs] GetBucketLocation api is not implemented

### DIFF
--- a/docs/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
+++ b/docs/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
@@ -44,7 +44,6 @@ The Ozone S3 Gateway implements a substantial subset of the Amazon S3 REST API. 
 | ✅ [CreateBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html) | Creates a new bucket. | **Non-compliant behavior:** The default bucket ACL may include extra group permissions instead of being strictly private. Bucket names must adhere to S3 naming conventions. |
 | ✅ [HeadBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html) | Checks for the existence of a bucket. | Returns a 200 status if the bucket exists. |
 | ✅ [DeleteBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html) | Deletes a bucket. | Bucket must be empty before deletion. |
-| ✅ [GetBucketLocation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html) | Retrieves the location (region) of a bucket. | Typically returns a default region (e.g., `us-east-1`), which may differ from AWS if region-specific responses are expected. |
 
 ### Object Operations
 

--- a/versioned_docs/version-2.1.0/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
+++ b/versioned_docs/version-2.1.0/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
@@ -44,7 +44,6 @@ The Ozone S3 Gateway implements a substantial subset of the Amazon S3 REST API. 
 | ✅ [CreateBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html) | Creates a new bucket. | **Non-compliant behavior:** The default bucket ACL may include extra group permissions instead of being strictly private. Bucket names must adhere to S3 naming conventions. |
 | ✅ [HeadBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html) | Checks for the existence of a bucket. | Returns a 200 status if the bucket exists. |
 | ✅ [DeleteBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html) | Deletes a bucket. | Bucket must be empty before deletion. |
-| ✅ [GetBucketLocation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html) | Retrieves the location (region) of a bucket. | Typically returns a default region (e.g., `us-east-1`), which may differ from AWS if region-specific responses are expected. |
 
 ### Object Operations
 


### PR DESCRIPTION
Please describe your PR in detail:
- The S3 GetBucketLocation API is not implemented.  This PR is to remove the GetBucketLocation api from the ozone-site docs.

## What is the link to the Apache Jira?
https://issues.apache.org/jira/browse/HDDS-15373

## How was this patch tested?
view docs in local Docker container

