### PR TITLE
HDDS-15427. [Docs] Update Release Manager Guide

### DIFF
--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -614,7 +614,7 @@ If there is a security vulnerability or critical bug uncovered in a major or min
 2. Run all steps from the sections [Update the Versions](#update-the-ozone-version-on-the-release-branch) through [Publish a Docker Image for the Release](#publish-a-docker-image-for-the-release), with the following modifications:
     - Do not update the protolock files unless protocol buffers were changed as part of the fix.
     - When updating the website, replace the superseded release's row on the [Downloads page](https://ozone.apache.org/download/) with this patch version, since users should no longer download the original release.
-      - For example, if 1.2.1 is released, the 1.2.0 row on the Downloads page should be replaced with 1.2.1.
+      - For example, if 1.2.1 is released, replace the 1.2.0 row on the Downloads page with 1.2.1.
       - Add release notes for the patch release under `src/pages/release-notes/` as described above in [Update the Ozone Website](#update-the-ozone-website). The release notes page for the original major/minor release can remain alongside the page for the patch release.
       - Remove the Downloads section from the superseded release's notes page, and point readers to the patch release's notes page instead. The superseded artifacts will be removed from the distribution site, so the old download links would no longer work.
     - In the event of a critical security vulnerability or seriously harmful bug with a small set of changes in the patch, PMC members may vote to forgo the usual 72 hour minimum time for a release vote and publish once there are enough binding +1s.

--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -613,7 +613,7 @@ If there is a security vulnerability or critical bug uncovered in a major or min
 
 2. Run all steps from the sections [Update the Versions](#update-the-ozone-version-on-the-release-branch) through [Publish a Docker Image for the Release](#publish-a-docker-image-for-the-release), with the following modifications:
     - Do not update the protolock files unless protocol buffers were changed as part of the fix.
-    - When updating the website, replace the superseded release's row on the [Downloads page](https://ozone.apache.org/download/) with this patch version, since we do not want users downloading the original release anymore.
+    - When updating the website, replace the superseded release's row on the [Downloads page](https://ozone.apache.org/download/) with this patch version, since users should no longer download the original release.
       - For example, if 1.2.1 is released, the 1.2.0 row on the Downloads page should be replaced with 1.2.1.
       - Add release notes for the patch release under `src/pages/release-notes/` as described above in [Update the Ozone Website](#update-the-ozone-website). The release notes page for the original major/minor release can remain alongside the page for the patch release.
       - Remove the Downloads section from the superseded release's notes page, and point readers to the patch release's notes page instead. The superseded artifacts will be removed from the distribution site, so the old download links would no longer work.

--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -522,15 +522,19 @@ To publish the artifacts to [Maven Central](https://central.sonatype.com), login
 
 ### Write a Haiku
 
-Check the tag from the [Ozone Roadmap](https://cwiki.apache.org/confluence/display/OZONE/Ozone+Roadmap) page (it's a national park).
+Check the release's national park tag, set in the `<ozone.release>` property of the project's top level pom (also shown by `bin/ozone version`).
 Find a photo which is under the CC license.
 Write a haiku to the photo with Future font.
 
 ### Update the Ozone Website
 
-1. Create release notes and add them to the Ozone website with your haiku image. An example pull request showing how to do this is [here](https://github.com/apache/ozone-site/pull/17). Note that the target branch is `master`. Please write the release notes in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. In particular, make sure it is human readable and not a simple commit log diffs.
-2. Extract the docs folder from the release tarball, and add its contents to the website. An example pull request for this is [here](https://github.com/apache/ozone-site/pull/18). Note that the target branch is `asf-site` , and that the `docs/current` symlink has been updated to point to the latest release's directory.
-3. Test the website locally by running `hugo serve` from the repository root with the master branch checked out. Check that links for the new release are working. Links to the documentation will not work until the PR to the `asf-site` branch is merged.
+The website is rendered from the `master` branch of the [apache/ozone-site](https://github.com/apache/ozone-site) repository. Open a pull request against the `master` branch that:
+
+1. Updates the [Downloads page](https://ozone.apache.org/download/) (`src/pages/download.md`) to include the artifacts of the new release version.
+2. Adds release notes for the new version under `src/pages/release-notes/` with your haiku image. Please write the release notes in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. In particular, make sure it is human readable and not a simple commit log diff.
+3. Creates a versioned copy of the documentation for the release. See [this pull request](https://github.com/apache/ozone-site/pull/330) for an example.
+
+Test the website locally by running `pnpm build` from the repository root to verify that it builds, then `pnpm serve` (or `pnpm start`) to browse the site and click through the new release's links. The build only validates internal links, so the links to the release artifacts must be checked manually.
 
 ### Add the Final Git Tag and Push It
 
@@ -576,14 +580,6 @@ Update the upgrade and client cross compatibility acceptance tests to check agai
 This step requires the release's [Docker image](#publish-a-docker-image-for-the-release) to be published.
 :::
 
-### Update the Ozone Roadmap
-
-1. Update the [Ozone Roadmap](https://cwiki.apache.org/confluence/display/OZONE/Ozone+Roadmap) so that the release notes for the just completed release are correct.
-
-2. Move its row to the `Past Releases` section.
-
-3. Create a row for the next release in the `Upcoming Releases` section, and add planned features that you are aware of.
-
 ### Update Apache Release Metadata
 
 1. Mark the version as released in Apache Jira HDDS project: https://issues.apache.org/jira/plugins/servlet/project-config/HDDS/administer-versions?status=unreleased
@@ -605,8 +601,8 @@ When a release is superseded or no longer supported, clean up old release refere
 
 Include the following links:
 
-- Release notes: https://ozone.apache.org/release/1.2.0/. Replace the version in the URL with the version being released.
-- Download link: https://ozone.apache.org/downloads/
+- Release notes: https://ozone.apache.org/release-notes/2.1.0/. Replace the version in the URL with the version being released.
+- Download link: https://ozone.apache.org/download/
 - Link to versioned documentation: https://ozone.apache.org/docs/
 
 ## Patch Release
@@ -617,11 +613,10 @@ If there is a security vulnerability or critical bug uncovered in a major or min
 
 2. Run all steps from the sections [Update the Versions](#update-the-ozone-version-on-the-release-branch) through [Publish a Docker Image for the Release](#publish-a-docker-image-for-the-release), with the following modifications:
     - Do not update the protolock files unless protocol buffers were changed as part of the fix.
-    - When updating the website, all instances of the original major/minor release should be replaced with this patch version, since we do not want users downloading the original release anymore.
-      - For example, any website text referring to 1.2.0 should be changed to refer to 1.2.1.
-      - Continuing the 1.2.0 to 1.2.1 example, the release/1.2.0 page should redirect to release/1.2.1.
-      - An example pull request to do this is [here](https://github.com/apache/ozone-site/pull/23).
-      - The docs can be added to the website normally as described above in [Update the Ozone Website](#update-the-ozone-website). The docs link for the original major/minor release can remain alongside the docs link for the patch release.
+    - When updating the website, replace the superseded release's row on the [Downloads page](https://ozone.apache.org/download/) with this patch version, since we do not want users downloading the original release anymore.
+      - For example, if 1.2.1 is released, the 1.2.0 row on the Downloads page should be replaced with 1.2.1.
+      - Add release notes for the patch release under `src/pages/release-notes/` as described above in [Update the Ozone Website](#update-the-ozone-website). The release notes page for the original major/minor release can remain alongside the page for the patch release.
+      - Remove the Downloads section from the superseded release's notes page, and point readers to the patch release's notes page instead. The superseded artifacts will be removed from the distribution site, so the old download links would no longer work.
     - In the event of a critical security vulnerability or seriously harmful bug with a small set of changes in the patch, PMC members may vote to forgo the usual 72 hour minimum time for a release vote and publish once there are enough binding +1s.
 
 3. Remove the previous release that this patch release supersedes from the Apache distribution site. e.g.:

--- a/docs/08-developer-guide/04-project/02-release-guide.md
+++ b/docs/08-developer-guide/04-project/02-release-guide.md
@@ -532,7 +532,7 @@ The website is rendered from the `master` branch of the [apache/ozone-site](http
 
 1. Updates the [Downloads page](https://ozone.apache.org/download/) (`src/pages/download.md`) to include the artifacts of the new release version.
 2. Adds release notes for the new version under `src/pages/release-notes/` with your haiku image. Please write the release notes in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. In particular, make sure it is human readable and not a simple commit log diff.
-3. Creates a versioned copy of the documentation for the release. See [this pull request](https://github.com/apache/ozone-site/pull/330) for an example.
+3. Creates a versioned copy of the documentation for the release. See [this pull request](https://github.com/apache/ozone-site/pull/330) for an example, and check out the instructions from the [Docusaurus website](https://docusaurus.io/docs/versioning#tagging-a-new-version).
 
 Test the website locally by running `pnpm build` from the repository root to verify that it builds, then `pnpm serve` (or `pnpm start`) to browse the site and click through the new release's links. The build only validates internal links, so the links to the release artifacts must be checked manually.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update the Release Manager Guide to reflect the new Docusaurus-based website workflow, since the website was migrated to render from the `master` branch of the ozone-site repo. The old Hugo/`asf-site` instructions no longer apply.

Changes requested in the Jira:

- Rewrite the "Update the Ozone Website" section: open a single PR against `master` in apache/ozone-site that updates the Downloads page (`src/pages/download.md`) and adds release notes under `src/pages/release-notes/`; test locally with `pnpm build` instead of `hugo serve`.
- Drop the "Update the Ozone Roadmap" section, since the wiki is no longer used.
- Fix the announcement mail links: release notes `https://ozone.apache.org/release/1.2.0/` -> `https://ozone.apache.org/release-notes/2.1.0`, download `https://ozone.apache.org/downloads/` -> `https://ozone.apache.org/download/`.

Additional changes beyond the Jira description, to clean up stale content left behind by the same website migration and wiki deprecation:

- "Write a Haiku": the national park tag was looked up on the now-deprecated Ozone Roadmap wiki page. Point to its actual source of truth instead: the `<ozone.release>` property in the project's top level pom (also shown by `bin/ozone version`).
- "Update the Ozone Website": added a step to create a versioned copy of the documentation for the release (with apache/ozone-site#330 as an example). The removed "extract the docs folder from the release tarball" step was the docs publishing step, so dropping it without a replacement would leave the guide with no instruction for publishing the release's documentation.
- "Patch Release": the website bullets still referenced the old site's `release/1.2.0` -> `release/1.2.1` redirect and a Hugo-era example PR (apache/ozone-site#23). Replaced them with the equivalent steps on the new site: replace the superseded release's row on the Downloads page, add release notes for the patch release, and remove the Downloads section from the superseded release's notes page (pointing readers to the patch release) since its artifacts are removed from the distribution site and redirects are not available in this setup.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-15427

## How was this patch tested?

- `pnpm build` succeeds (also validates internal links/anchors).
- `markdownlint` and `cspell` pass on the changed file.
- Verified the rendered page locally with `pnpm start`.
