### PR TITLE
HDDS-15714. Group actions/cache version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
     cronjob: 15 11 * * *
   cooldown:
     default-days: 7
+  groups:
+    # Bump actions/cache, actions/cache/save, actions/cache/restore at the same time
+    actions-cache:
+      patterns:
+      - actions/cache*


### PR DESCRIPTION
## What changes were proposed in this pull request?

Attempt to group updates of `actions/cache`, `actions/cache/restore`, `actions/cache/save` in the same PR.  These are parts of the same action, released at the same time, should be bumped together to reduce workflow runs, but currently Dependabot creates separate pull requests:

- #476
- #477
- #478

https://issues.apache.org/jira/browse/HDDS-15714

## How was this patch tested?

Functionality would be validated after merge, the next time dependabot attempts updates.

CI:
https://github.com/adoroszlai/ozone-site/actions/runs/28442098384