### PR TITLE
HDDS-15584. Add supported awscli version paragraph to user guide

### DIFF
--- a/docs/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
+++ b/docs/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
@@ -177,8 +177,8 @@ aws s3 ls --endpoint http://localhost:9878 s3://buckettest
 
 #### Supported AWS CLI Versions
 
-- AWS CLI v1 (1.36.0 and above) and AWS CLI v2 (2.23.0 and above) are supported by Apache Ozone 2.1 and above.
-- [AWS has announced AWS CLI v1 enters maintenance mode on July 15, 2026](https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/); users are encouraged to upgrade to AWS CLI v2. Support for AWS CLI v1 may be dropped at some point in the future.
+- AWS CLI v1 (1.37.0 and above) and AWS CLI v2 (2.23.0 and above) are supported. These are the versions in which AWS enabled [default data integrity protections](https://github.com/aws/aws-cli/issues/9214) that automatically calculate a `CRC32` checksum for S3 uploads; Ozone added handling for that flow in 2.1 and later.
+- [AWS has announced AWS CLI v1 enters maintenance mode on July 15, 2026](https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/); users are encouraged to upgrade to AWS CLI v2. Ozone may drop support for AWS CLI v1 at some point in the future.
 
 ## Compatible third-party applications
 

--- a/docs/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
+++ b/docs/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
@@ -175,6 +175,11 @@ Or
 aws s3 ls --endpoint http://localhost:9878 s3://buckettest
 ```
 
+#### Supported AWS CLI Versions
+
+- AWS CLI v1 (1.36.0 and above) and AWS CLI v2 (2.23.0 and above) are supported by Apache Ozone 2.1 and above.
+- [AWS has announced AWS CLI v1 enters maintenance mode on July 15, 2026](https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/); users are encouraged to upgrade to AWS CLI v2. Support for AWS CLI v1 may be dropped at some point in the future.
+
 ## Compatible third-party applications
 
 Ozone's S3 Gateway enables integration with a wide range of cloud-native and analytics applications. Here are some examples of tools and platforms known to work with Ozone (in alphabetical order):

--- a/versioned_docs/version-2.1.0/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
+++ b/versioned_docs/version-2.1.0/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
@@ -177,8 +177,8 @@ aws s3 ls --endpoint http://localhost:9878 s3://buckettest
 
 #### Supported AWS CLI Versions
 
-- AWS CLI v1 (1.36.0 and above) and AWS CLI v2 (2.23.0 and above) are supported by Apache Ozone 2.1 and above.
-- [AWS has announced AWS CLI v1 enters maintenance mode on July 15, 2026](https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/); users are encouraged to upgrade to AWS CLI v2. Support for AWS CLI v1 may be dropped at some point in the future.
+- AWS CLI v1 (1.37.0 and above) and AWS CLI v2 (2.23.0 and above) are supported. These are the versions in which AWS enabled [default data integrity protections](https://github.com/aws/aws-cli/issues/9214) that automatically calculate a `CRC32` checksum for S3 uploads; Ozone added handling for that flow in 2.1 and later.
+- [AWS has announced AWS CLI v1 enters maintenance mode on July 15, 2026](https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/); users are encouraged to upgrade to AWS CLI v2. Ozone may drop support for AWS CLI v1 at some point in the future.
 
 ## Compatible third-party applications
 

--- a/versioned_docs/version-2.1.0/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
+++ b/versioned_docs/version-2.1.0/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
@@ -175,6 +175,11 @@ Or
 aws s3 ls --endpoint http://localhost:9878 s3://buckettest
 ```
 
+#### Supported AWS CLI Versions
+
+- AWS CLI v1 (1.36.0 and above) and AWS CLI v2 (2.23.0 and above) are supported by Apache Ozone 2.1 and above.
+- [AWS has announced AWS CLI v1 enters maintenance mode on July 15, 2026](https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/); users are encouraged to upgrade to AWS CLI v2. Support for AWS CLI v1 may be dropped at some point in the future.
+
 ## Compatible third-party applications
 
 Ozone's S3 Gateway enables integration with a wide range of cloud-native and analytics applications. Here are some examples of tools and platforms known to work with Ozone (in alphabetical order):

--- a/versioned_docs/version-2.1.1/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
+++ b/versioned_docs/version-2.1.1/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
@@ -177,8 +177,8 @@ aws s3 ls --endpoint http://localhost:9878 s3://buckettest
 
 #### Supported AWS CLI Versions
 
-- AWS CLI v1 (1.36.0 and above) and AWS CLI v2 (2.23.0 and above) are supported by Apache Ozone 2.1 and above.
-- [AWS has announced AWS CLI v1 enters maintenance mode on July 15, 2026](https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/); users are encouraged to upgrade to AWS CLI v2. Support for AWS CLI v1 may be dropped at some point in the future.
+- AWS CLI v1 (1.37.0 and above) and AWS CLI v2 (2.23.0 and above) are supported. These are the versions in which AWS enabled [default data integrity protections](https://github.com/aws/aws-cli/issues/9214) that automatically calculate a `CRC32` checksum for S3 uploads; Ozone added handling for that flow in 2.1 and later.
+- [AWS has announced AWS CLI v1 enters maintenance mode on July 15, 2026](https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/); users are encouraged to upgrade to AWS CLI v2. Ozone may drop support for AWS CLI v1 at some point in the future.
 
 ## Compatible third-party applications
 

--- a/versioned_docs/version-2.1.1/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
+++ b/versioned_docs/version-2.1.1/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md
@@ -175,6 +175,11 @@ Or
 aws s3 ls --endpoint http://localhost:9878 s3://buckettest
 ```
 
+#### Supported AWS CLI Versions
+
+- AWS CLI v1 (1.36.0 and above) and AWS CLI v2 (2.23.0 and above) are supported by Apache Ozone 2.1 and above.
+- [AWS has announced AWS CLI v1 enters maintenance mode on July 15, 2026](https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/); users are encouraged to upgrade to AWS CLI v2. Support for AWS CLI v1 may be dropped at some point in the future.
+
 ## Compatible third-party applications
 
 Ozone's S3 Gateway enables integration with a wide range of cloud-native and analytics applications. Here are some examples of tools and platforms known to work with Ozone (in alphabetical order):


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Adds a new "Supported AWS CLI Versions" subsection to docs/04-user-guide/01-client-interfaces/03-s3/01-s3-api.md, nested under the existing "AWS CLI" section.
- Documents the minimum-supported AWS CLI versions for Apache Ozone 2.1+: AWS CLI v1 ≥ 1.36.0 and AWS CLI v2 ≥ 2.23.0.
- Notes that AWS CLI v1 enters maintenance mode on July 15, 2026 and recommends upgrading to v2, with a link out to the AWS announcement.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-15584

## How was this patch tested?

- The context shows successfully on the local server.
- The link to AWS's announcement also works fine.

<img width="1468" height="880" alt="image" src="https://github.com/user-attachments/assets/85ed046a-a8c6-4d9f-9a3b-10d920357d74" />

