### PR TITLE
HDDS-15725. zizmor check should reflect failure in fork

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -62,7 +62,6 @@ jobs:
         persist-credentials: false
     - name: Enable corepack
       run: |
-        npm i -g --force corepack # see https://github.com/actions/setup-node/issues/1222
         corepack enable
     - name: Use Node.js ${{ env.node_version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -88,7 +87,6 @@ jobs:
         persist-credentials: false
     - name: Enable corepack
       run: |
-        npm i -g --force corepack # see https://github.com/actions/setup-node/issues/1222
         corepack enable
     - name: Use Node.js ${{ env.node_version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -108,7 +106,6 @@ jobs:
         persist-credentials: false
     - name: Enable corepack
       run: |
-        npm i -g --force corepack # see https://github.com/actions/setup-node/issues/1222
         corepack enable
     - name: Use Node.js ${{ env.node_version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,9 +20,17 @@ on:
     branches-ignore:
     - automated-config-doc-update
     - dependabot/**
+    paths:
+    - .github/workflows/**
   pull_request:
+    paths:
+    - .github/workflows/**
 
 permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
 
 jobs:
   zizmor:
@@ -37,3 +45,5 @@ jobs:
 
     - name: Run zizmor
       uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+      with:
+        advanced-security: ${{ github.repository_owner == 'apache' }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -29,7 +29,9 @@ on:
 permissions: { }
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  group: >
+    ${{ github.workflow }}-
+    ${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ FROM node:${NODE_VERSION}-slim AS base
 # Creates store at /pnpm/store by default.
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm i -g --force corepack # see https://github.com/actions/setup-node/issues/1222
 RUN corepack enable
 
 # Install dependencies to /ozone-site/node_modules as part of the image.


### PR DESCRIPTION
## What changes were proposed in this pull request?

zizmor workflow added in HDDS-14920 provides feedback via "Code scanning results".  The workflow itself passes even if it finds issues to be fixed.  This does not work well in forks where code scanning is disabled.

Revert #125, which was supposed to be a temporary workaround.  This fixes [violation](https://github.com/adoroszlai/ozone-site/actions/runs/28587410342/job/84762351903): `ad-hoc installation of packages`.

Additional tweak:
- run zizmor check only for workflow changes

Also adopts the following change from other Ozone repos:
- HDDS-15527. Cancel superseded PR runs

https://issues.apache.org/jira/browse/HDDS-15725

## How was this patch tested?

Tested in `ozone` repo:

Without the patch passes despite intentional violation:
https://github.com/adoroszlai/ozone/actions/runs/28570405264/job/84706670204#step:3:1058

Same violation with the patch fails:
https://github.com/adoroszlai/ozone/actions/runs/28570585965/job/84707233189#step:3:208

The patch without intentional violation passes (also in this repo):
https://github.com/adoroszlai/ozone/actions/runs/28570809169/job/84707932173#step:3:107
https://github.com/adoroszlai/ozone-site/actions/runs/28589642852

CI:
https://github.com/adoroszlai/ozone-site/actions/runs/28589642835