### PR TITLE
HDDS-15613. Publish the Read Operation Implementation doc

### DIFF
--- a/docs/07-system-internals/02-data-operations/02-read.md
+++ b/docs/07-system-internals/02-data-operations/02-read.md
@@ -1,5 +1,4 @@
 ---
-draft: true
 sidebar_label: Read
 ---
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The system internals doc on the Read operation is complete but was marked `draft` and hidden from the website. This removes the `draft: true` frontmatter flag so the page is published.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-15613

## How was this patch tested?

- `npm run build` succeeds
- The page is emitted at `build/docs/system-internals/data-operations/read/index.html` (drafts are excluded from production builds, confirming it is now published).
- `markdownlint` passes.