### PR TITLE
HDDS-15719. Add check for allowed action usage in workflows

### DIFF
--- a/.github/workflows/asf-allowlist-check.yaml
+++ b/.github/workflows/asf-allowlist-check.yaml
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ASF Allowlist Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+    - .github/workflows/**
+  push:
+    branches-ignore:
+    - automated-config-doc-update
+    - dependabot/**
+    paths:
+    - .github/workflows/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >
+    ${{ github.workflow }}-
+    ${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-slim
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+    - name: Check actions
+      uses: apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3
+      with:
+        scan-glob: .github/workflows/*.y*ml


### PR DESCRIPTION
## What changes were proposed in this pull request?

GitHub workflows may fail silently when using any actions not allowed by ASF Infra.  See https://github.com/apache/infrastructure-actions/issues/574 for details.

This change adds a new check that verifies action usage in workflows.  See https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md

https://issues.apache.org/jira/browse/HDDS-15719

## How was this patch tested?

asf-allowlist-check: https://github.com/adoroszlai/ozone-site/actions/runs/28707933976/job/85136613970#step:3:30

```
Checking 10 unique action ref(s) against the ASF allowlist:

  ✅ actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 — trusted owner (actions)  (.github/workflows/docusaurus.yml, .github/workflows/docusaurus.yml)
  ✅ actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 — trusted owner (actions)  (.github/workflows/docusaurus.yml)
  ✅ actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 — trusted owner (actions)  (.github/workflows/docusaurus.yml)
  ✅ actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 — trusted owner (actions)  (.github/workflows/asf-allowlist-check.yaml, .github/workflows/docusaurus.yml, .github/workflows/docusaurus.yml, .github/workflows/docusaurus.yml, .github/workflows/publish.yml, .github/workflows/pull-request.yml, .github/workflows/static.yml, .github/workflows/static.yml, .github/workflows/static.yml, .github/workflows/static.yml, .github/workflows/static.yml, .github/workflows/zizmor.yml)
  ✅ actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c — trusted owner (actions)  (.github/workflows/docusaurus.yml, .github/workflows/publish.yml)
  ✅ actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e — trusted owner (actions)  (.github/workflows/static.yml, .github/workflows/static.yml, .github/workflows/static.yml)
  ✅ actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a — trusted owner (actions)  (.github/workflows/docusaurus.yml)
  ✅ apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3 — trusted owner (apache)  (.github/workflows/asf-allowlist-check.yaml)
  ✅ apache/skywalking-eyes@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 — trusted owner (apache)  (.github/workflows/static.yml)
  ✅ zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa — matches allowlist  (.github/workflows/zizmor.yml)
All 10 unique action refs are on the ASF allowlist
```
