### PR TITLE
HDDS-14343. Apache Knox integration documentation and Docker Compose demo

### DIFF
--- a/docs/04-user-guide/01-client-interfaces/05-httpfs.md
+++ b/docs/04-user-guide/01-client-interfaces/05-httpfs.md
@@ -22,6 +22,10 @@ The **WebHDFS** client FileSystem implementation can be used to access HttpFS us
 If HttpFS is fronted by a **load balancer** and you use Kerberos (SPNEGO), clients obtain tickets for the load balancer’s hostname. Configure the HttpFS HTTP principal and keytab accordingly; see [HttpFS behind a load balancer (Kerberos)](../../administrator-guide/configuration/performance/httpfs-load-balancer).
 :::
 
+:::note
+If HttpFS is fronted by **Apache Knox**, configure a proxy user for Knox and access HttpFS through the Knox gateway URL. See [Configuring Apache Knox](../../administrator-guide/configuration/security/knox).
+:::
+
 ## Getting started
 
 To try it out, follow the [instructions](../../quick-start/installation/docker) to start the Ozone cluster with Docker Compose.

--- a/docs/05-administrator-guide/02-configuration/03-security/04-knox.md
+++ b/docs/05-administrator-guide/02-configuration/03-security/04-knox.md
@@ -4,7 +4,7 @@ sidebar_label: Apache Knox
 
 # Configuring Apache Knox
 
-[Apache Knox](https://knox.apache.org/) is a reverse proxy gateway for Hadoop ecosystem REST APIs and web UIs. Knox 2.0.0 and later can proxy Ozone services, giving users a single HTTPS entry point while hiding internal cluster hostnames and ports.
+[Apache Knox](https://knox.apache.org/) is a reverse proxy gateway for Hadoop ecosystem REST APIs and web UIs. Knox 2.0.0 and later can proxy Ozone web UIs (OM, SCM, and Recon). Knox **2.1.0 or later** is required to proxy HttpFS. Knox gives users a single HTTPS entry point while hiding internal cluster hostnames and ports.
 
 Ozone integration was added in [KNOX-2833](https://issues.apache.org/jira/browse/KNOX-2833) (OM, SCM, and Recon UIs) and extended in [KNOX-2914](https://issues.apache.org/jira/browse/KNOX-2914) (HttpFS). Knox does **not** proxy the S3 Gateway today; use a load balancer or direct S3G access instead.
 
@@ -19,7 +19,8 @@ Ozone integration was added in [KNOX-2833](https://issues.apache.org/jira/browse
 
 ## Prerequisites
 
-- Apache Knox **2.0.0 or later** installed and running.
+- Apache Knox **2.0.0 or later** installed and running to proxy Ozone web UIs.
+- Apache Knox **2.1.0 or later** if you proxy HttpFS through Knox.
 - Ozone HTTP endpoints reachable from the Knox host (`ozone.om.http-address`, `ozone.scm.http-address`, `ozone.recon.http-address`, and HttpFS on port 14000 by default).
 - For production: configure TLS on Knox and Kerberos SPNEGO on Ozone HTTP services. See [HTTPS / SPNEGO](./https) and [Kerberos](./kerberos).
 
@@ -130,7 +131,7 @@ For Kerberized Ozone clusters:
 
 ### HttpFS proxy user
 
-When Knox proxies HttpFS, configure a proxy user on the HttpFS service so Knox can impersonate end users. Add the following to `httpfs-site.xml` (or the equivalent `CORE-SITE.XML_` environment variables in Docker):
+When Knox proxies HttpFS, configure a proxy user on the HttpFS service so Knox can impersonate end users. Add the following to `httpfs-site.xml`:
 
 ```xml
 <property>
@@ -187,10 +188,10 @@ Access HttpFS through Knox using the `/httpfs/` path prefix:
 
 ```bash
 curl -ik -u guest:guest-password \
-  "https://localhost:8443/gateway/ozone/httpfs/v1/?op=LISTSTATUS&user.name=hadoop"
+  "https://<knox-host>:8443/gateway/ozone/httpfs/v1/?op=LISTSTATUS&user.name=hadoop"
 ```
 
-The `user.name` parameter specifies the Ozone user to impersonate. Knox authenticates the caller; HttpFS performs the operation as the proxied user.
+Knox authenticates the caller and rewrites `user.name` to the authenticated Knox user (for example, `guest` in the demo topology). HttpFS performs the operation as that proxied user.
 
 ## Docker quickstart
 
@@ -203,6 +204,8 @@ mkdir knox-ozone && cd knox-ozone
 curl -O https://raw.githubusercontent.com/apache/ozone-site/master/static/compose/knox-ozone/docker-compose.yaml
 curl -O https://raw.githubusercontent.com/apache/ozone-site/master/static/compose/knox-ozone/Dockerfile
 mkdir -p conf/topologies
+curl -o conf/httpfs-site.xml \
+  https://raw.githubusercontent.com/apache/ozone-site/master/static/compose/knox-ozone/conf/httpfs-site.xml
 curl -o conf/topologies/ozone.xml \
   https://raw.githubusercontent.com/apache/ozone-site/master/static/compose/knox-ozone/conf/topologies/ozone.xml
 curl -o conf/topologies/knoxsso.xml \
@@ -215,7 +218,7 @@ curl -o conf/topologies/knoxsso.xml \
 docker compose up -d --scale datanode=1
 ```
 
-This starts Ozone (SCM, OM, Recon, S3G, HttpFS, one Datanode), Knox demo LDAP, and the Knox gateway with the `ozone` and `knoxsso` topologies mounted. The `knoxsso` topology is required for browser login — it must point LDAP at the `knox-ldap` service hostname, not `localhost`.
+This starts Ozone (SCM, OM, Recon, S3G, HttpFS, one Datanode), Knox demo LDAP, and the Knox gateway with the `ozone` and `knoxsso` topologies mounted. The compose stack mounts `conf/httpfs-site.xml` on the HttpFS service for Knox proxy-user settings. The `knoxsso` topology is required for browser login — it must point LDAP at the `knox-ldap` service hostname, not `localhost`.
 
 ### Verify access
 

--- a/docs/05-administrator-guide/02-configuration/03-security/04-knox.md
+++ b/docs/05-administrator-guide/02-configuration/03-security/04-knox.md
@@ -1,9 +1,251 @@
 ---
-draft: true
 sidebar_label: Apache Knox
 ---
 
 # Configuring Apache Knox
 
-**TODO:** File a subtask under [HDDS-9859](https://issues.apache.org/jira/browse/HDDS-9859) and complete this page or section.
-**TODO:** Uncomment link to this page in src/pages/index.js
+[Apache Knox](https://knox.apache.org/) is a reverse proxy gateway for Hadoop ecosystem REST APIs and web UIs. Knox 2.0.0 and later can proxy Ozone services, giving users a single HTTPS entry point while hiding internal cluster hostnames and ports.
+
+Ozone integration was added in [KNOX-2833](https://issues.apache.org/jira/browse/KNOX-2833) (OM, SCM, and Recon UIs) and extended in [KNOX-2914](https://issues.apache.org/jira/browse/KNOX-2914) (HttpFS). Knox does **not** proxy the S3 Gateway today; use a load balancer or direct S3G access instead.
+
+## Supported Ozone services
+
+| Knox service role | Ozone component | Default HTTP port | Knox path prefix |
+|---|---|---|---|
+| `OZONE` | Ozone Manager UI | 9874 | `/ozone/` |
+| `OZONE-SCM` | Storage Container Manager UI | 9876 | `/ozone-scm/` |
+| `OZONE-RECON` | Recon UI | 9888 | `/ozone-recon/` |
+| `OZONE-HTTPFS` | HttpFS Gateway | 14000 | `/httpfs/` |
+
+## Prerequisites
+
+- Apache Knox **2.0.0 or later** installed and running.
+- Ozone HTTP endpoints reachable from the Knox host (`ozone.om.http-address`, `ozone.scm.http-address`, `ozone.recon.http-address`, and HttpFS on port 14000 by default).
+- For production: configure TLS on Knox and Kerberos SPNEGO on Ozone HTTP services. See [HTTPS / SPNEGO](./https) and [Kerberos](./kerberos).
+
+## Topology configuration
+
+Knox routes traffic based on **topology** XML files in `{GATEWAY_HOME}/conf/topologies/`. Create a topology (for example `ozone.xml`) that declares authentication providers and Ozone backend URLs.
+
+### Example topology
+
+The following example uses Knox demo LDAP for authentication. Replace hostnames and ports with your cluster values.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<topology>
+    <gateway>
+        <provider>
+            <role>authentication</role>
+            <name>ShiroProvider</name>
+            <enabled>true</enabled>
+            <param>
+                <name>sessionTimeout</name>
+                <value>30</value>
+            </param>
+            <param>
+                <name>main.ldapRealm</name>
+                <value>org.apache.knox.gateway.shirorealm.KnoxLdapRealm</value>
+            </param>
+            <param>
+                <name>main.ldapContextFactory</name>
+                <value>org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory</name>
+                <value>$ldapContextFactory</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.userDnTemplate</name>
+                <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory.url</name>
+                <value>ldap://knox-ldap.example.com:33389</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
+                <value>simple</value>
+            </param>
+            <param>
+                <name>urls./**</name>
+                <value>authcBasic</value>
+            </param>
+        </provider>
+
+        <provider>
+            <role>identity-assertion</role>
+            <name>Default</name>
+            <enabled>true</enabled>
+        </provider>
+
+        <provider>
+            <role>hostmap</role>
+            <name>static</name>
+            <enabled>true</enabled>
+            <param>
+                <name>om1.example.com</name>
+                <value>om1.internal.example.com</value>
+            </param>
+        </provider>
+    </gateway>
+
+    <service>
+        <role>OZONE</role>
+        <url>http://om1.internal.example.com:9874</url>
+    </service>
+
+    <service>
+        <role>OZONE-SCM</role>
+        <url>http://scm1.internal.example.com:9876</url>
+    </service>
+
+    <service>
+        <role>OZONE-RECON</role>
+        <url>http://recon.internal.example.com:9888</url>
+    </service>
+
+    <service>
+        <role>OZONE-HTTPFS</role>
+        <url>http://httpfs.internal.example.com:14000/webhdfs/</url>
+    </service>
+</topology>
+```
+
+Place the file in `{GATEWAY_HOME}/conf/topologies/ozone.xml`. Knox automatically redeploys the topology when the file changes.
+
+### High availability
+
+When multiple Ozone Managers or SCMs run in HA, add a `<service>` entry for each instance. Knox uses a `?host={host}` query parameter on OM and SCM UI links so the gateway routes to the correct backend ([KNOX-2930](https://github.com/apache/knox/pull/767)). Configure the `hostmap` provider to rewrite internal hostnames embedded in UI responses.
+
+### Secure clusters
+
+For Kerberized Ozone clusters:
+
+1. Enable SPNEGO on Ozone HTTP services as described in [HTTPS / SPNEGO](./https).
+2. Configure Knox authentication with your enterprise identity provider (LDAP, SAML, or Kerberos) instead of demo LDAP.
+3. Terminate TLS at Knox and use HTTPS between Knox and Ozone backends where possible.
+
+## Ozone-side configuration
+
+### HttpFS proxy user
+
+When Knox proxies HttpFS, configure a proxy user on the HttpFS service so Knox can impersonate end users. Add the following to `httpfs-site.xml` (or the equivalent `CORE-SITE.XML_` environment variables in Docker):
+
+```xml
+<property>
+  <name>httpfs.proxyuser.knoxuser.hosts</name>
+  <value>*</value>
+</property>
+<property>
+  <name>httpfs.proxyuser.knoxuser.groups</name>
+  <value>*</value>
+</property>
+```
+
+Replace `knoxuser` with the Unix or service account Knox uses to connect to HttpFS. Restrict `hosts` and `groups` in production. See [HttpFS Gateway](../../../user-guide/client-interfaces/httpfs#proxy-user-configuration) for details.
+
+### HTTP addresses
+
+Ensure each proxied service publishes the HTTP address Knox will use:
+
+| Property | Example |
+|---|---|
+| `ozone.om.http-address` | `om1.example.com:9874` |
+| `ozone.scm.http-address` | `scm1.example.com:9876` |
+| `ozone.recon.http-address` | `recon.example.com:9888` |
+
+## Accessing Ozone through Knox
+
+After Knox and the topology are deployed, users reach Ozone through the Knox gateway URL.
+
+### Knox homepage
+
+Open the Knox homepage to see Ozone service cards:
+
+```text
+https://<knox-host>:8443/gateway/homepage/home
+```
+
+Authenticate with the credentials configured in the topology (for example, demo LDAP user `guest` with password `guest-password`).
+
+### Web UIs
+
+Direct links follow this pattern. For OM and SCM, the `host` query parameter must be the full backend URL (not just the hostname):
+
+```text
+https://<knox-host>:8443/gateway/ozone/ozone/index.html?host=http://<om-host>:9874
+https://<knox-host>:8443/gateway/ozone/ozone-scm/index.html?host=http://<scm-host>:9876
+https://<knox-host>:8443/gateway/ozone/ozone-recon/index.html
+```
+
+Replace `ozone` in the path with your topology name if different. In HA deployments, use the URL of the specific OM or SCM instance you want to reach.
+
+### HttpFS REST API
+
+Access HttpFS through Knox using the `/httpfs/` path prefix:
+
+```bash
+curl -ik -u guest:guest-password \
+  "https://localhost:8443/gateway/ozone/httpfs/v1/?op=LISTSTATUS&user.name=hadoop"
+```
+
+The `user.name` parameter specifies the Ozone user to impersonate. Knox authenticates the caller; HttpFS performs the operation as the proxied user.
+
+## Docker quickstart
+
+A sample Docker Compose stack that runs Ozone with Knox is available in this repository.
+
+### Download the compose files
+
+```bash
+mkdir knox-ozone && cd knox-ozone
+curl -O https://raw.githubusercontent.com/apache/ozone-site/master/static/compose/knox-ozone/docker-compose.yaml
+curl -O https://raw.githubusercontent.com/apache/ozone-site/master/static/compose/knox-ozone/Dockerfile
+mkdir -p conf/topologies
+curl -o conf/topologies/ozone.xml \
+  https://raw.githubusercontent.com/apache/ozone-site/master/static/compose/knox-ozone/conf/topologies/ozone.xml
+curl -o conf/topologies/knoxsso.xml \
+  https://raw.githubusercontent.com/apache/ozone-site/master/static/compose/knox-ozone/conf/topologies/knoxsso.xml
+```
+
+### Start the stack
+
+```bash
+docker compose up -d --scale datanode=1
+```
+
+This starts Ozone (SCM, OM, Recon, S3G, HttpFS, one Datanode), Knox demo LDAP, and the Knox gateway with the `ozone` and `knoxsso` topologies mounted. The `knoxsso` topology is required for browser login — it must point LDAP at the `knox-ldap` service hostname, not `localhost`.
+
+### Verify access
+
+1. Wait about one minute for Knox to finish initializing, then open the Knox homepage:
+
+   ```text
+   https://localhost:8443/gateway/homepage/home
+   ```
+
+2. Log in with `guest` / `guest-password`.
+
+3. Click the Ozone Manager, SCM, or Recon cards to open the proxied UIs. If a card does not load, open the UI directly using the full backend URL in the `host` parameter (for example, `?host=http://om:9874` for OM).
+
+4. Test HttpFS through Knox:
+
+   ```bash
+   curl -ik -u guest:guest-password \
+     "https://localhost:8443/gateway/ozone/httpfs/v1/?op=LISTSTATUS&user.name=hadoop"
+   ```
+
+### Stop the stack
+
+```bash
+docker compose down -v
+```
+
+## References
+
+- [Apache Knox 2.0 User Guide](https://knox.apache.org/books/knox-2-0-0/user-guide.html)
+- [KNOX-2833 — Ozone UI integration](https://issues.apache.org/jira/browse/KNOX-2833)
+- [KNOX-2914 — Ozone HttpFS integration](https://issues.apache.org/jira/browse/KNOX-2914)
+- [HttpFS Gateway](../../../user-guide/client-interfaces/httpfs)
+- [HTTPS / SPNEGO](./https)

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -301,7 +301,7 @@ function Integrations() {
           }}
         />
       ),
-      // link: '/docs/administrator-guide/configuration/security/knox'
+      link: "/docs/administrator-guide/configuration/security/knox",
     },
     {
       name: "Kerberos",

--- a/static/compose/knox-ozone/Dockerfile
+++ b/static/compose/knox-ozone/Dockerfile
@@ -15,7 +15,7 @@
 
 # Optional image that bakes the Ozone topology into the official Knox gateway
 # image. The default docker-compose.yaml mounts the topology instead.
-FROM apache/knox:latest
+FROM apache/knox:2.1.0
 
 COPY conf/topologies/ozone.xml /home/knox/knox/conf/topologies/ozone.xml
 COPY conf/topologies/knoxsso.xml /home/knox/knox/conf/topologies/knoxsso.xml

--- a/static/compose/knox-ozone/Dockerfile
+++ b/static/compose/knox-ozone/Dockerfile
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Optional image that bakes the Ozone topology into the official Knox gateway
+# image. The default docker-compose.yaml mounts the topology instead.
+FROM apache/knox:latest
+
+COPY conf/topologies/ozone.xml /home/knox/knox/conf/topologies/ozone.xml
+COPY conf/topologies/knoxsso.xml /home/knox/knox/conf/topologies/knoxsso.xml

--- a/static/compose/knox-ozone/conf/httpfs-site.xml
+++ b/static/compose/knox-ozone/conf/httpfs-site.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0"?>
-<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
-  The ASF licenses this file to you under the Apache License, Version 2.0
+  The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <configuration>
   <property>
     <name>httpfs.proxyuser.knoxuser.hosts</name>

--- a/static/compose/knox-ozone/conf/httpfs-site.xml
+++ b/static/compose/knox-ozone/conf/httpfs-site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+  <property>
+    <name>httpfs.proxyuser.knoxuser.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>httpfs.proxyuser.knoxuser.groups</name>
+    <value>*</value>
+  </property>
+</configuration>

--- a/static/compose/knox-ozone/conf/topologies/knoxsso.xml
+++ b/static/compose/knox-ozone/conf/topologies/knoxsso.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<topology>
+    <gateway>
+      <provider>
+        <role>webappsec</role>
+        <name>WebAppSec</name>
+        <enabled>true</enabled>
+        <param><name>xframe.options.enabled</name><value>true</value></param>
+      </provider>
+
+        <provider>
+            <role>authentication</role>
+            <name>ShiroProvider</name>
+            <enabled>true</enabled>
+            <param>
+                <name>sessionTimeout</name>
+                <value>30</value>
+            </param>
+            <param>
+                <name>redirectToUrl</name>
+                <value>/${GATEWAY_PATH}/knoxsso/knoxauth/login.html</value>
+            </param>
+            <param>
+                <name>restrictedCookies</name>
+                <value>rememberme,WWW-Authenticate</value>
+            </param>
+            <param>
+                <name>main.ldapRealm</name>
+                <value>org.apache.knox.gateway.shirorealm.KnoxLdapRealm</value>
+            </param>
+            <param>
+                <name>main.ldapContextFactory</name>
+                <value>org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory</name>
+                <value>$ldapContextFactory</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.userDnTemplate</name>
+                <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory.url</name>
+                <value>ldap://knox-ldap:33389</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.authenticationCachingEnabled</name>
+                <value>false</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
+                <value>simple</value>
+            </param>
+            <param>
+                <name>urls./**</name>
+                <value>authcBasic</value>
+            </param>
+        </provider>
+
+        <provider>
+            <role>identity-assertion</role>
+            <name>Default</name>
+            <enabled>true</enabled>
+        </provider>
+
+        <provider>
+            <role>hostmap</role>
+            <name>static</name>
+            <enabled>true</enabled>
+            <param>
+                <name>localhost</name>
+                <value>sandbox,sandbox.hortonworks.com</value>
+            </param>
+        </provider>
+
+    </gateway>
+
+    <application>
+      <name>knoxauth</name>
+    </application>
+
+    <service>
+        <role>KNOXSSO</role>
+        <param>
+            <name>knoxsso.token.ttl</name>
+            <value>86400000</value>
+        </param>
+        <param>
+            <name>knox.token.exp.server-managed</name>
+            <value>false</value>
+        </param>
+    </service>
+
+</topology>

--- a/static/compose/knox-ozone/conf/topologies/ozone.xml
+++ b/static/compose/knox-ozone/conf/topologies/ozone.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<topology>
+    <gateway>
+        <provider>
+            <role>authentication</role>
+            <name>ShiroProvider</name>
+            <enabled>true</enabled>
+            <param>
+                <name>sessionTimeout</name>
+                <value>30</value>
+            </param>
+            <param>
+                <name>main.ldapRealm</name>
+                <value>org.apache.knox.gateway.shirorealm.KnoxLdapRealm</value>
+            </param>
+            <param>
+                <name>main.ldapContextFactory</name>
+                <value>org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory</name>
+                <value>$ldapContextFactory</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.userDnTemplate</name>
+                <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory.url</name>
+                <value>ldap://knox-ldap:33389</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
+                <value>simple</value>
+            </param>
+            <param>
+                <name>urls./**</name>
+                <value>authcBasic</value>
+            </param>
+        </provider>
+
+        <provider>
+            <role>identity-assertion</role>
+            <name>Default</name>
+            <enabled>true</enabled>
+        </provider>
+
+        <provider>
+            <role>hostmap</role>
+            <name>static</name>
+            <enabled>true</enabled>
+            <param>
+                <name>om</name>
+                <value>om</value>
+            </param>
+            <param>
+                <name>scm</name>
+                <value>scm</value>
+            </param>
+            <param>
+                <name>recon</name>
+                <value>recon</value>
+            </param>
+            <param>
+                <name>httpfs</name>
+                <value>httpfs</value>
+            </param>
+        </provider>
+    </gateway>
+
+    <service>
+        <role>OZONE</role>
+        <url>http://om:9874</url>
+    </service>
+
+    <service>
+        <role>OZONE-SCM</role>
+        <url>http://scm:9876</url>
+    </service>
+
+    <service>
+        <role>OZONE-RECON</role>
+        <url>http://recon:9888</url>
+    </service>
+
+    <service>
+        <role>OZONE-HTTPFS</role>
+        <url>http://httpfs:14000/webhdfs/</url>
+    </service>
+</topology>

--- a/static/compose/knox-ozone/docker-compose.yaml
+++ b/static/compose/knox-ozone/docker-compose.yaml
@@ -1,0 +1,119 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+x-image:
+  &image
+  image: ${OZONE_IMAGE:-apache/ozone}:${OZONE_IMAGE_VERSION:-2.1.1}${OZONE_IMAGE_FLAVOR:-}
+
+x-common-config:
+  &common-config
+  OZONE-SITE.XML_hdds.datanode.dir: /data/hdds
+  OZONE-SITE.XML_ozone.metadata.dirs: /data/metadata
+  OZONE-SITE.XML_ozone.om.address: om
+  OZONE-SITE.XML_ozone.om.http-address: om:9874
+  OZONE-SITE.XML_ozone.recon.address: recon:9891
+  OZONE-SITE.XML_ozone.recon.db.dir: /data/metadata/recon
+  OZONE-SITE.XML_ozone.recon.http-address: recon:9888
+  OZONE-SITE.XML_ozone.replication: "1"
+  OZONE-SITE.XML_ozone.scm.block.client.address: scm
+  OZONE-SITE.XML_ozone.scm.client.address: scm
+  OZONE-SITE.XML_ozone.scm.datanode.id.dir: /data/metadata
+  OZONE-SITE.XML_ozone.scm.http-address: scm:9876
+  OZONE-SITE.XML_ozone.scm.names: scm
+  OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "1"
+  OZONE-SITE.XML_hdds.scm.safemode.healthy.pipeline.pct: "0"
+  no_proxy: om,recon,scm,s3g,httpfs,knox-ldap,knox-gateway,localhost,127.0.0.1
+
+version: "3"
+services:
+  datanode:
+    <<: *image
+    ports:
+    - 9864
+    command: [ ozone, datanode ]
+    environment:
+      <<: *common-config
+
+  om:
+    <<: *image
+    ports:
+    - 9874:9874
+    environment:
+      <<: *common-config
+      CORE-SITE.XML_hadoop.proxyuser.hadoop.hosts: "*"
+      CORE-SITE.XML_hadoop.proxyuser.hadoop.groups: "*"
+      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      WAITFOR: scm:9876
+    command: [ ozone, om ]
+
+  scm:
+    <<: *image
+    ports:
+    - 9876:9876
+    environment:
+      <<: *common-config
+      ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
+    command: [ ozone, scm ]
+
+  recon:
+    <<: *image
+    ports:
+    - 9888:9888
+    environment:
+      <<: *common-config
+    command: [ ozone, recon ]
+
+  s3g:
+    <<: *image
+    ports:
+    - 9878:9878
+    environment:
+      <<: *common-config
+    command: [ ozone, s3g ]
+
+  httpfs:
+    <<: *image
+    ports:
+    - 14000:14000
+    environment:
+      <<: *common-config
+      CORE-SITE.XML_fs.defaultFS: ofs://om
+      CORE-SITE.XML_httpfs.proxyuser.knoxuser.hosts: "*"
+      CORE-SITE.XML_httpfs.proxyuser.knoxuser.groups: "*"
+    command: [ ozone, httpfs ]
+
+  knox-ldap:
+    image: ${KNOX_IMAGE:-apache/knox}:${KNOX_IMAGE_VERSION:-latest}
+    entrypoint: [ /bin/bash, -c ]
+    command:
+    - |
+      /home/knox/knox/bin/ldap.sh start
+      tail -f /home/knox/knox/logs/ldap.out
+    ports:
+    - 33389:33389
+
+  knox-gateway:
+    image: ${KNOX_IMAGE:-apache/knox}:${KNOX_IMAGE_VERSION:-latest}
+    depends_on:
+    - knox-ldap
+    - om
+    - scm
+    - recon
+    - httpfs
+    ports:
+    - 8443:8443
+    volumes:
+    - ./conf/topologies/ozone.xml:/home/knox/knox/conf/topologies/ozone.xml:ro
+    - ./conf/topologies/knoxsso.xml:/home/knox/knox/conf/topologies/knoxsso.xml:ro

--- a/static/compose/knox-ozone/docker-compose.yaml
+++ b/static/compose/knox-ozone/docker-compose.yaml
@@ -36,7 +36,6 @@ x-common-config:
   OZONE-SITE.XML_hdds.scm.safemode.healthy.pipeline.pct: "0"
   no_proxy: om,recon,scm,s3g,httpfs,knox-ldap,knox-gateway,localhost,127.0.0.1
 
-version: "3"
 services:
   datanode:
     <<: *image
@@ -90,12 +89,12 @@ services:
     environment:
       <<: *common-config
       CORE-SITE.XML_fs.defaultFS: ofs://om
-      CORE-SITE.XML_httpfs.proxyuser.knoxuser.hosts: "*"
-      CORE-SITE.XML_httpfs.proxyuser.knoxuser.groups: "*"
+    volumes:
+    - ./conf/httpfs-site.xml:/opt/hadoop/etc/hadoop/httpfs-site.xml:ro
     command: [ ozone, httpfs ]
 
   knox-ldap:
-    image: ${KNOX_IMAGE:-apache/knox}:${KNOX_IMAGE_VERSION:-latest}
+    image: ${KNOX_IMAGE:-apache/knox}:${KNOX_IMAGE_VERSION:-2.1.0}
     entrypoint: [ /bin/bash, -c ]
     command:
     - |
@@ -105,7 +104,7 @@ services:
     - 33389:33389
 
   knox-gateway:
-    image: ${KNOX_IMAGE:-apache/knox}:${KNOX_IMAGE_VERSION:-latest}
+    image: ${KNOX_IMAGE:-apache/knox}:${KNOX_IMAGE_VERSION:-2.1.0}
     depends_on:
     - knox-ldap
     - om


### PR DESCRIPTION
## Summary
- Add administrator guide for configuring Apache Knox with Ozone (OM, SCM, Recon UIs and HttpFS), including user access instructions and a Docker Compose quickstart under `static/compose/knox-ozone/`.
- Fix Knox browser login in Docker by mounting `knoxsso.xml` with LDAP pointed at the `knox-ldap` service (default image topology uses `localhost`).
- Enable the Knox integration card on the homepage and cross-link from the HttpFS user guide.

## Jira
https://issues.apache.org/jira/browse/HDDS-14343

## Test plan
- [x] `pnpm build` passes with no broken links
- [x] `pnpm exec yamllint static/compose/knox-ozone/docker-compose.yaml` passes
- [x] `docker compose up -d --scale datanode=1` in `static/compose/knox-ozone/` starts all services
- [x] Knox homepage login works with `guest` / `guest-password`
- [x] OM, SCM, and Recon UIs reachable via Knox (OM/SCM need `?host=http://...`)
- [x] HttpFS `LISTSTATUS` works through Knox at `/gateway/ozone/httpfs/v1/`

<img width="1460" height="959" alt="Screenshot 2026-07-13 at 10 21 40 PM" src="https://github.com/user-attachments/assets/485087af-4caf-470e-a353-7b97fdf4b862" />
