### PR TITLE
HDDS-15884. Allow GitHub avatar sources in blog CSP

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -14,4 +14,5 @@
 # limitations under the License.
 
 # CSP permissions for ozone.apache.org - Adding 3rd party service Algolia. Approved by VP Data Privacy.
-SetEnv CSP_PROJECT_DOMAINS "https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/"
+# GitHub avatars used on the blog contributor cards (HDDS-15884).
+SetEnv CSP_PROJECT_DOMAINS "https://*.algolia.net/ https://*.algolianet.com/ https://*.algolia.io/ https://github.com/ https://*.githubusercontent.com/"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `https://github.com/` and `https://*.githubusercontent.com/` to `CSP_PROJECT_DOMAINS` in `static/.htaccess`.

Please describe your PR in detail:

The blog contributor cards use `image_url: https://github.com/<user>.png` for individual authors (see `blog/authors.yml`). That URL 302-redirects to `avatars.githubusercontent.com`, so the browser needs CSP permission for **both** origins. No `img-src` is set today, so `default-src` applies and blocks the images — the contributor avatars don't render.

JIRA: https://issues.apache.org/jira/browse/HDDS-15884

## Alternative
Bundle avatars into the repo and point `authors.yml` at local paths. Avoids the CSP change and the redirect hop, but every contributor add/refresh becomes a commit. Happy to switch if reviewers prefer.

## How was this patch tested?

- Redirect chain confirmed: `curl -sI https://github.com/<user>.png` → `HTTP/2 302` → `location: https://avatars.githubusercontent.com/...`, so CSP must allow both origins.
- Local httpd 2.4 smoke test with this `.htaccess` plus a stub `Header set Content-Security-Policy ... %{CSP_PROJECT_DOMAINS}e ...` emits both `https://github.com/` and `https://*.githubusercontent.com/` in the resulting header. Reverting the patch drops both origins; restoring it puts them back.

