### PR TITLE
HDDS-15947. Fix incorrect user documentation link in website repository checklist

### DIFF
--- a/docs/08-developer-guide/04-project/01-git/03-feature-branches/03-merged-branches/16-hdds-8342-s3-lifecycle-configurations.md
+++ b/docs/08-developer-guide/04-project/01-git/03-feature-branches/03-merged-branches/16-hdds-8342-s3-lifecycle-configurations.md
@@ -11,11 +11,11 @@ The plan is to run repeated CI checks on the merge commit to master.
 
 ## 2. Documentation
 
-[User Documentation](https://github.com/apache/ozone/blob/HDDS-8342/hadoop-hdds/docs/content/feature/Lifecycle.md) or S3 Lifecycle Configuration - Object Expiration has been added.
+[User Documentation](https://ozone.apache.org/docs/next/administrator-guide/operations/object-lifecycle) for S3 Lifecycle Configuration - Object Expiration has been added.
 
 ## 3. Design, attached the docs
 
-Design document can be found here : [S3 Lifecycle Configuration - Object Expiration Design Doc](https://github.com/apache/ozone/blob/HDDS-8342/hadoop-hdds/docs/content/design/s3-object-lifecycle-management.md).
+Design document can be found here : [S3 Lifecycle Configuration - Object Expiration Design Doc](https://github.com/apache/ozone/blob/master/hadoop-hdds/docs/content/design/s3-object-lifecycle-management.md).
 
 ## 4. S3 compatibility
 
@@ -23,7 +23,7 @@ N/A, only the object expiration action of S3 Lifecycle configuration is supporte
 
 ## 5. Docker-compose / Acceptance tests
 
-New robot test [`om-lifecycle.robot`](https://github.com/apache/ozone/blob/HDDS-8342/hadoop-ozone/dist/src/main/smoketest/lifecycle/om-lifecycle.robot) and [`bucketlifecycle.robot`](https://github.com/apache/ozone/blob/HDDS-8342/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot) are being added.
+New robot test [`om-lifecycle.robot`](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/smoketest/lifecycle/om-lifecycle.robot) and [`bucketlifecycle.robot`](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/smoketest/s3/bucketlifecycle.robot) are being added.
 
 Comprehensive tests with fault injection were added. The major one is [TestKeyLifecycleService](https://github.com/apache/ozone/blob/HDDS-8342/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyLifecycleService.java).
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A few of the links used in the checklist were referring to the feature branch documentation. This PR updates those references to point to the master branch documentation, as the feature has now been merged into master.

https://github.com/apache/ozone/pull/10829 is removing all the feature docs, So just updated feature doc link to website link.

## What is the link to the Apache Jira?

HDDS-15947

## How was this patch tested?

Tested locally using docker-compose.
