### PR TITLE
HDDS-15999. Add GitHub Action to trigger Algolia crawler reindex on demand.

### DIFF
--- a/.github/resource/algolia_reindex_secrets.md
+++ b/.github/resource/algolia_reindex_secrets.md
@@ -1,0 +1,13 @@
+# Algolia crawler reindex — GitHub Actions secrets
+
+The [`algolia-reindex` workflow](../workflows/algolia-reindex.yml) needs three repository secrets before it can call the Algolia Crawler API. Add them under **Settings → Secrets and variables → Actions** on `apache/ozone-site` (ASF repo admins).
+
+| Secret | Where to find it in Algolia |
+| --- | --- |
+| `ALGOLIA_CRAWLER_USER_ID` | Crawler → **Settings** tab → Crawler User Id |
+| `ALGOLIA_CRAWLER_API_KEY` | Crawler → **Settings** tab → Crawler API Key |
+| `ALGOLIA_CRAWLER_ID` | Your crawler → Configuration → **Settings** → Crawler ID |
+
+Do not commit these values to the repository. The search-only API key in `docusaurus.config.js` cannot trigger crawls.
+
+After secrets are configured, run **Actions → algolia-reindex → Run workflow** with **force** enabled to verify the crawl starts in the Algolia Crawler dashboard.

--- a/.github/scripts/algolia_reindex.sh
+++ b/.github/scripts/algolia_reindex.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Triggers an Algolia Crawler reindex via the Crawler REST API.
+# Requires: ALGOLIA_CRAWLER_ID, ALGOLIA_CRAWLER_USER_ID, ALGOLIA_CRAWLER_API_KEY
+
+set -eu
+
+for var in ALGOLIA_CRAWLER_ID ALGOLIA_CRAWLER_USER_ID ALGOLIA_CRAWLER_API_KEY; do
+  eval "val=\${$var:-}"
+  if [ -z "$val" ]; then
+    echo "Missing required environment variable: $var" >&2
+    exit 1
+  fi
+done
+
+api_url="https://crawler.algolia.com/api/1/crawlers/${ALGOLIA_CRAWLER_ID}/reindex"
+response_file="$(mktemp)"
+trap 'rm -f "$response_file"' EXIT
+
+http_code="$(
+  curl -sS -o "$response_file" -w '%{http_code}' \
+    -X POST \
+    -u "${ALGOLIA_CRAWLER_USER_ID}:${ALGOLIA_CRAWLER_API_KEY}" \
+    "$api_url"
+)"
+
+body="$(cat "$response_file")"
+echo "Algolia Crawler reindex response (HTTP ${http_code}):"
+echo "$body"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo '## Algolia Crawler reindex'
+    echo ''
+    echo "**HTTP status:** ${http_code}"
+    echo ''
+    echo '```json'
+    echo "$body"
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+case "$http_code" in
+  2??) exit 0 ;;
+  *) exit 1 ;;
+esac

--- a/.github/workflows/algolia-reindex.yml
+++ b/.github/workflows/algolia-reindex.yml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Triggers Algolia DocSearch crawler reindex on demand or when master had commits in the last 24 hours.
+#
+# Required repository secrets (Settings → Secrets and variables → Actions):
+#   ALGOLIA_CRAWLER_USER_ID — Crawler dashboard → Settings → Crawler User Id
+#   ALGOLIA_CRAWLER_API_KEY — Crawler dashboard → Settings → Crawler API Key
+#   ALGOLIA_CRAWLER_ID      — Your crawler → Configuration → Settings → Crawler ID
+
+name: algolia-reindex
+
+on:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Skip the 24-hour master commit check and always reindex
+        type: boolean
+        default: false
+  schedule:
+    - cron: '0 12 * * *'
+
+concurrency:
+  group: algolia-reindex
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  script_dir: .github/scripts
+
+jobs:
+  reindex:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout master
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: master
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Check whether reindex is needed
+      id: gate
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force }}" = "true" ]; then
+          echo "should_reindex=true" >> "$GITHUB_OUTPUT"
+          echo "Forced reindex via workflow_dispatch."
+          exit 0
+        fi
+        git fetch origin master
+        count="$(git rev-list --count origin/master --since='24 hours ago')"
+        echo "Commits on master in the last 24 hours: ${count}"
+        if [ "$count" -gt 0 ]; then
+          echo "should_reindex=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "should_reindex=false" >> "$GITHUB_OUTPUT"
+          echo "Skipping reindex: no master commits in the last 24 hours."
+        fi
+    - name: Trigger Algolia crawler reindex
+      if: steps.gate.outputs.should_reindex == 'true'
+      working-directory: ${{ env.script_dir }}
+      env:
+        ALGOLIA_CRAWLER_ID: ${{ secrets.ALGOLIA_CRAWLER_ID }}
+        ALGOLIA_CRAWLER_USER_ID: ${{ secrets.ALGOLIA_CRAWLER_USER_ID }}
+        ALGOLIA_CRAWLER_API_KEY: ${{ secrets.ALGOLIA_CRAWLER_API_KEY }}
+      run: |
+        chmod +x ./algolia_reindex.sh
+        ./algolia_reindex.sh

--- a/.github/workflows/algolia-reindex.yml
+++ b/.github/workflows/algolia-reindex.yml
@@ -30,7 +30,7 @@ on:
         type: boolean
         default: false
   schedule:
-    - cron: '0 12 * * *'
+  - cron: 0 12 * * *
 
 concurrency:
   group: algolia-reindex


### PR DESCRIPTION
## Summary

- Add `algolia-reindex` GitHub Actions workflow with manual dispatch (optional `force`) and a daily schedule that reindexes only when `master` had commits in the last 24 hours.
- Add `.github/scripts/algolia_reindex.sh` to call the Algolia Crawler REST API reindex endpoint.
- Document required repository secrets for ASF repo admins in `.github/resource/algolia_reindex_secrets.md`.

https://issues.apache.org/jira/browse/HDDS-15999

Validated on a fork: [algolia-reindex workflow runs](https://github.com/jojochuang/ozone-site/actions/workflows/algolia-reindex.yml).

## Post-merge (repo admins)

Configure Actions **repository secrets** on `apache/ozone-site`: `ALGOLIA_CRAWLER_USER_ID`, `ALGOLIA_CRAWLER_API_KEY`, `ALGOLIA_CRAWLER_ID` (see `.github/resource/algolia_reindex_secrets.md`).

## Test plan

- [ ] Merge; add the three repository secrets.
- [ ] Actions → `algolia-reindex` → Run workflow with **force** → HTTP 2xx and new crawl in Algolia dashboard.
- [ ] Scheduled run skips when `master` has no commits in 24h; triggers when it does.
- [ ] `pnpm lint` passes (yamllint for workflow schedule block).


Made with [Cursor](https://cursor.com)