### PR TITLE
HDDS-16232. Document how to enable Jersey debug logs in S3 Gateway

### DIFF
--- a/docs/05-administrator-guide/02-configuration/02-logging/01-application-logs.md
+++ b/docs/05-administrator-guide/02-configuration/02-logging/01-application-logs.md
@@ -52,6 +52,37 @@ rootLogger.level = debug
 
 After saving the file and restarting the service, the service will start logging more detailed debug information.
 
+#### Enabling Jersey Debug Logs in S3 Gateway
+
+Jersey uses `java.util.logging` (JUL). S3 Gateway forwards JUL records to SLF4J,
+but JUL checks the log level before forwarding a record. Therefore, both JUL
+and log4j must allow debug records.
+
+Create a JUL configuration file, for example
+`$OZONE_CONF_DIR/s3g-jul-logging.properties`, with the following content:
+
+```properties
+org.glassfish.jersey.level = FINE
+```
+
+`FINE` is the JUL level that maps to SLF4J `DEBUG`. This setting enables it only
+for Jersey loggers.
+
+Add the following line to `$OZONE_CONF_DIR/log4j.properties`:
+
+```properties
+log4j.logger.org.glassfish.jersey=DEBUG
+```
+
+Configure S3 Gateway to use the JUL properties file by adding the following to
+`$OZONE_CONF_DIR/ozone-env.sh`:
+
+```bash
+export OZONE_S3G_OPTS="${OZONE_S3G_OPTS} -Djava.util.logging.config.file=${OZONE_CONF_DIR}/s3g-jul-logging.properties"
+```
+
+Restart S3 Gateway for the changes to take effect.
+
 ### Changing Service Log Levels at Runtime
 
 Use `ozone daemonlog` to inspect or change the log level of a running Ozone


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-8096](https://issues.apache.org/jira/browse/HDDS-8096) ([apache/ozone#11005](https://github.com/apache/ozone/pull/11005)) redirects Jersey logs from JUL to SLF4J so they are written to the S3 Gateway log file.

JUL checks the log level before a record reaches `SLF4JBridgeHandler`. Therefore, setting only `log4j.logger.org.glassfish.jersey=DEBUG` does not enable Jersey debug logs.

This change documents how to set the Jersey JUL logger to `FINE`, enable its `DEBUG` level in log4j, and load the JUL configuration when starting S3 Gateway.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-16232

## How was this patch tested?

- `pnpm exec markdownlint docs/05-administrator-guide/02-configuration/02-logging/01-application-logs.md`
- `pnpm build`
- Verified in a separate JVM that a Jersey JUL `FINE` record reaches reload4j only when JUL is set to `FINE` and log4j is set to `DEBUG`.
