### PR TITLE
HDDS-16234. Favicon missing on all non-root pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,6 +26,10 @@ const {themes} = require('prism-react-renderer');
 const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
 
+// Set the /<baseUrl>/ pathname under which your site is served
+// For GitHub pages deployment, it is often '/<projectName>/'
+const baseUrl = '/';
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Apache Ozone',
@@ -34,9 +38,7 @@ const config = {
   // This must match the URL the website is hosted at for social media previews to work.
   // If you are testing the social media image (themeConfig.image) locally, set this to http://localhost:3001.
   url: 'https://ozone.apache.org',
-  // Set the /<baseUrl>/ pathname under which your site is served
-  // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl,
 
   // Fail the build if there are any broken links.
   onBrokenLinks: 'throw',
@@ -62,7 +64,7 @@ const config = {
       tagName: 'link',
       attributes: {
         rel: 'icon',
-        href: 'favicon.ico',
+        href: `${baseUrl}favicon.ico`,
         sizes: '32x32'
       },
     },
@@ -70,7 +72,7 @@ const config = {
       tagName: 'link',
       attributes: {
         rel: 'icon',
-        href: 'favicon.svg',
+        href: `${baseUrl}favicon.svg`,
         type: "image/svg+xml"
       },
     },
@@ -78,7 +80,7 @@ const config = {
       tagName: 'link',
       attributes: {
         rel: 'apple-touch-icon',
-        href: 'apple-touch-icon.png',
+        href: `${baseUrl}apple-touch-icon.png`,
       },
     },
     {


### PR DESCRIPTION

## What changes were proposed in this pull request?

The favicon `<link>` tags in `docusaurus.config.js`'s `headTags` used relative `href` values (e.g. `href: 'favicon.ico'`) with no leading `/`. Since there's no `<base>` tag on the page, browsers resolve these relative to the current page URL rather than the site root. This only happened to work on `/` (resolves to `/favicon.ico`, 200); on any other page it resolved to a nested, non-existent path (e.g. `/blog/favicon.ico`, 404), so the favicon failed to load on every non-root page (docs, blog, roadmap, etc.).

This PR makes the three `headTags` favicon entries build their `href` from the site's `baseUrl` instead of hardcoding a bare relative path, so they always resolve to the site root regardless of page depth.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16234

## How was this patch tested?

Reproduced the bug first, then verified the fix, using docker compose

- Before the fix, `curl` against `/`, `/docs/.../ozone-manager/`, and `/blog/` all emitted the same relative `href="favicon.ico"` markup, but the resolved nested path (e.g. `/docs/.../ozone-manager/favicon.ico`) returned 404 while the root path returned 200 — confirming the bug.
- After the fix, the same three pages emit `href="/favicon.ico"` (and `favicon.svg`, `apple-touch-icon.png`), which all resolve to 200 regardless of page depth.

Before the fix:
<img width="1183" height="86" alt="before fix" src="https://github.com/user-attachments/assets/5a33ef95-e0ae-4403-a7de-a69e49933f2a" />

After the fix:
<img width="1135" height="77" alt="after fix" src="https://github.com/user-attachments/assets/8e8575e3-74d6-4f0d-a7d3-ced5c1a788b1" />

