### PR TITLE
HDDS-16018. Update DNS-to-switch mapping documentation

### DIFF
--- a/docs/05-administrator-guide/02-configuration/04-performance/02-topology.md
+++ b/docs/05-administrator-guide/02-configuration/04-performance/02-topology.md
@@ -22,7 +22,7 @@ See the [page about Containers](../../../core-concepts/replication/storage-conta
 
 ## Configuring Topology Hierarchy
 
-Ozone determines Datanode network locations (e.g., racks) using Hadoop's rack awareness, configured via `net.topology.node.switch.mapping.impl` in `ozone-site.xml`. This key specifies a `org.apache.hadoop.net.CachedDNSToSwitchMapping` implementation. [1]
+Ozone determines Datanode network locations (e.g., racks) using Hadoop's rack awareness, configured via `net.topology.node.switch.mapping.impl` in `ozone-site.xml`. The value of this key is the class name of an implementation of `org.apache.hadoop.net.DNSToSwitchMapping`. [1]
 
 :::note
 Both Ozone Manager (OM) and Storage Container Manager (SCM) use network topology information. It is critical to maintain a consistent topology assignment across all OM and SCM instances in the cluster.


### PR DESCRIPTION
## What changes were proposed in this pull request?

The network topology documentation is updated to identify `net.topology.node.switch.mapping.impl` as a `DNSToSwitchMapping` implementation instead of a `CachedDNSToSwitchMapping` implementation. This aligns the website documentation with https://github.com/apache/ozone/pull/10911.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-16018

## How was this patch tested?

CI: https://github.com/F64116045/ozone-site/actions
