### PR TITLE
HDDS-16384. Document Recon fileSize bin semantics in recon-api.yaml

### DIFF
--- a/static/recon-api.yaml
+++ b/static/recon-api.yaml
@@ -759,7 +759,7 @@ paths:
     get:
       tags:
         - Utilization
-      summary: Returns the file counts within different file ranges with fileSize in the response object being the upper cap for file size range.
+      summary: Returns file counts by size bin, with fileSize representing the bin upper bound.
       operationId: getFileCounts
       parameters:
         - name: volume
@@ -779,12 +779,17 @@ paths:
         - name: fileSize
           in: query
           description: |
-            Filters the results based on the given file size.<br>
+            Filters the results by the exact upper bound of a file-size histogram bin, in bytes.<br>
+            It is not an arbitrary file size or a cumulative less-than-or-equal threshold.<br>
+            A positive value that is not a bin upper bound returns an empty result.<br>
+            The first bin has an upper bound of 1024 bytes; for example, the bin with upper bound 2048 contains files larger than 1024 bytes and up to 2048 bytes.<br>
+            This filter can be used independently or together with volume and/or bucket.<br>
             The smallest file size being tracked for count is 1 KB i.e. 1024 bytes.
           example: 1024
           required: false
           schema:
-            type: number
+            type: integer
+            format: int64
       responses:
         '200':
           description: Successful Operation


### PR DESCRIPTION
## What changes were proposed in this pull request?

`fileSize` on `/utilization/fileCount` only matches the exact upper bound of a histogram bin, not an arbitrary size, so the old description was misleading. This mirrors apache/ozone#11204 and also fixes the schema to `integer / int64`, since the endpoint parses it as a long.

Should land after apache/ozone#11203 and apache/ozone#11204.

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-16384

## How was this patch tested?

Parsed the YAML locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
